### PR TITLE
Add ilattice integration guidance and building-blocks assessment

### DIFF
--- a/ROADMAP_MVP.md
+++ b/ROADMAP_MVP.md
@@ -1,0 +1,108 @@
+# Planetary Cellular Automata Roadmap (Room → Planet)
+
+This roadmap outlines concrete steps and code glue required to scale the current Bevy voxel engine from room-sized simulations to a destructible planet with gravity pointed toward its core and real-time slicing.
+
+## Stage 0 — Room-Scale Prototype
+1. **Data Model**
+   - Store CA state in a dense 3D array per chunk (`Vec<[State; CHUNK_VOLUME]>`). Use existing Bevy ECS chunk entities with `Component` resources for voxels.
+   - Add a `SimulationSpeed` resource to scale `Time::delta_seconds()` when the CA cost exceeds budget.
+2. **Simulation Loop**
+   - Implement systems scheduled in a custom `UpdateSet::Simulation` before rendering to maintain determinism.
+   - Example system:
+     ```rust
+     fn step_chunk(
+         mut chunks: Query<(&ChunkCells, &mut ChunkCellsNext)>,
+         sim_speed: Res<SimulationSpeed>,
+         pool: Res<ComputeTaskPool>,
+     ) {
+         pool.scope(|scope| {
+             for (cells, mut next) in chunks.iter_mut() {
+                 scope.spawn(async move {
+                     next.copy_from(cells);
+                     run_room_rules(&mut next.0, sim_speed.factor);
+                 });
+             }
+         });
+     }
+     ```
+     Uses `bevy_tasks::ComputeTaskPool` for parallel iteration ([bevy_tasks README](https://github.com/bevyengine/bevy/tree/main/crates/bevy_tasks)).
+3. **Rendering**
+   - Mesh each chunk via compute shader or CPU mesher per frame; upload using asynchronous asset pipeline (`RenderAssetUsages::REQUIRES_ASSET_LOADING`).
+4. **Testing**
+   - Validate chunk stepping using `cargo test --all-targets` with deterministic seeds.
+
+## Stage 1 — Building / City Scale (~1 km)
+1. **Chunk Paging**
+   - Swap dense arrays into a paging layer keyed by `IVec3` chunk coordinates (hash map or `slotmap`). Stream chunks using background tasks.
+2. **Gravity Core**
+   - Introduce global resource `PlanetCenter: DVec3` and compute gravity vector per voxel: `let dir = (planet_center - world_pos).normalize();` apply to particle/physics proxies.
+3. **Performance Controls**
+   - Implement budget monitor: track average ms per chunk update; reduce `SimulationSpeed` or update subsets (e.g., even/odd chunk shells) when exceeding `target_ms`.
+4. **Visualization**
+   - Add instanced rendering per material state to keep entity count low; emit GPU buffers grouped by chunk.
+5. **Persistence**
+   - Serialize chunk arrays to disk when evicted; store metadata with version, seed, and simulation tick for reproducible reloads.
+
+## Stage 2 — Regional Scale (~100 km)
+1. **Adopt `big_space` Coordinates**
+   - Add dependency `big_space = { version = "0.10", features = ["bevy"] }`.
+   - Register plugin and components:
+     ```rust
+     app.add_plugins(BigSpacePlugin::default())
+         .add_systems(Startup, setup_space);
+
+     fn setup_space(mut commands: Commands) {
+         commands.spawn((BigSpace::default(), SpatialBundle::default()));
+         commands.spawn((FloatingOrigin, Camera3dBundle::default(), Grid::new(GridPrecision::Int64, 1024.0)));
+     }
+     ```
+     ([Big Space README](https://github.com/aevyrie/big_space/blob/main/README.md#highlights)).
+   - Each chunk entity stores `GridCell` + local `Transform`; CA systems operate on `(grid_cell, local_index)` pairs to avoid precision loss ([docs.rs Integer Grid](https://docs.rs/big_space/latest/big_space/#integer-grid)).
+2. **Spatial Hashing**
+   - Maintain `GridHashMap` for active chunks to fetch neighbors in O(1) ([docs.rs Quick Reference](https://docs.rs/big_space/latest/big_space/)).
+   - Use hashed partitions to parallelize CA updates by independent regions.
+3. **Morton Ordering with `ilattice`**
+   - Add `ilattice = { version = "0.4", features = ["glam"] }` for cache-friendly Morton indexing of chunks and intra-chunk tiles.
+   - Store a `MortonKey(u64)` component generated via `MortonEncoder3D::encode(chunk_coords)` to stabilize streaming order and GPU buffer packing.
+   - Decode keys with `morton_decode3d` when scheduling neighbor updates to avoid precision loss while still benefiting from Z-order locality.
+4. **Level of Detail**
+   - Downsample chunk data into `8³` or `16³` macro cells for mid-distance; update LODs asynchronously and swap into impostor meshes.
+5. **Time Dilation**
+   - Introduce scheduler that advances different latitudinal bands on alternating frames to cap per-frame cost; ensure CA remains stable by using semi-implicit integration for diffusive rules.
+
+## Stage 3 — Planetary Scale (~6,000 km radius)
+1. **Hierarchical Storage**
+   - Combine chunk paging with an overlay `oktree` for sparse phenomena (storms, fractures). Use `Octree::from_aabb_with_capacity` to track sparse activations ([docs.rs example](https://docs.rs/oktree/0.4.1/oktree/#example)).
+   - Store dense mantle in compressed bricks (e.g., `RLE` or `SparseSet`) and hydrate into active chunks near player or fracture front.
+   - Reuse `ilattice` Morton keys to map bricks within streaming caches and to align octree leaves with chunk clipmap tiers.
+2. **Gravity & Physics**
+   - Compute gravity vector in high-precision space: `let offset = big_space.absolute_position(entity);` then accelerate toward center.
+   - Integrate with physics engine (Rapier or custom) by converting to local coordinates each frame while using double precision for calculations.
+3. **Planet Slicing**
+   - For real-time cuts, identify intersected chunks via `oktree` ray queries; re-mesh on worker threads.
+   - Use compute shaders to carve geometry: upload plane equation, run compute pipeline that updates voxel states and rebuilds mesh buffers.
+4. **Streaming & Networking**
+   - Prefetch ahead-of-time using orbital prediction: compute future camera grid cells using velocity and gravity, request data from disk or network.
+   - Serialize states with chunk diffs plus `GridCell` metadata for deterministic reassembly.
+5. **Visualization**
+   - Implement atmospheric scattering shader and horizon-based culling. For far side of planet, use spherical harmonic approximation fed by aggregated CA metrics.
+
+## Stage 4 — Planetary Optimization Loop
+1. **Performance Budgeting**
+   - Target frame budget of 16 ms. Allocate 6 ms for CA, 4 ms for meshing, 4 ms for rendering, 2 ms margin.
+   - If CA exceeds budget, reduce simulation frequency or resolution (dynamic chunk size) via `SimulationSpeed` resource.
+2. **GPU Memory Forecast (16 GB)**
+   - Reserve 4 GB for render targets/textures, 1 GB for uniform/storage buffers, leaving ~11 GB for chunk meshes.
+   - At 1 MB per chunk mesh (e.g., `32³` voxels with position/normal/color), ~11k chunks can be resident simultaneously. Use streaming + compression for additional coverage.
+3. **Tooling**
+   - Build profiling overlays to visualize chunk budgets, task latency, and recenter frequency.
+   - Add automated tests for chunk streaming, recenter correctness, and CA determinism across floating-origin transitions.
+4. **Library Vetting**
+   - Use `ilattice` for Morton math; avoid pulling `building-blocks` into the MVP due to maintenance hiatus. Instead, port its clipmap and compression concepts into bespoke ECS systems, keeping Bevy integration first-class while retaining the option to prototype against the crate off-branch.
+
+## Stage 5 — Shipping Checklist
+- Validate deterministic replay across saves.
+- Stress-test by slicing the planet repeatedly; monitor rebuild latency and ensure simulation slowdown remains smooth.
+- Document configuration knobs (chunk size, LOD radius, simulation budget) for tuning to different GPUs.
+
+By following these stages, the engine progresses from a room-scale automaton to a planetary simulation that respects precision, performance, and memory constraints while integrating `big_space` and `oktree` effectively.

--- a/docs/big_space_research.md
+++ b/docs/big_space_research.md
@@ -1,0 +1,42 @@
+# `big_space` Coordinate System Research
+
+## Highlights
+- Big Space advertises "huge worlds, high performance, no dependencies" and reuses `Transform`/`GlobalTransform` so existing Bevy systems continue to function ([README](https://github.com/aevyrie/big_space)).
+- Supports precision from proton to observable-universe scale by chaining integer grids (`i8` up to `i128`) and floating origins ([README highlights](https://github.com/aevyrie/big_space/blob/main/README.md#highlights)).
+- Provides spatial hashing (`GridHashMap`) and partitioning helpers to accelerate neighbor lookup for large entity sets ([docs.rs Quick Reference](https://docs.rs/big_space/latest/big_space/)).
+
+## Core Concepts
+- **BigSpace**: root component that anchors a high-precision hierarchy and holds grid parameters for descendants.
+- **FloatingOrigin**: entity whose transform defines the local render origin, minimizing floating point error for 32-bit GPU transforms ([docs.rs Floating Origin](https://docs.rs/big_space/latest/big_space/#floating-origin)).
+- **Grid / GridCell**: define integer cell size and indices for nested grids, letting you partition the world into coarse-to-fine spatial buckets without coordinate drift ([docs.rs Integer Grid](https://docs.rs/big_space/latest/big_space/#integer-grid)).
+
+## Integration Sketch
+```rust
+use big_space::prelude::*;
+use bevy::prelude::*;
+
+fn setup(mut commands: Commands) {
+    commands.spawn((BigSpace::default(), SpatialBundle::default()));
+    commands.spawn((
+        FloatingOrigin,
+        Camera3dBundle::default(),
+        Grid::new(GridPrecision::Int64, 1024.0),
+    ));
+    commands.spawn((
+        GridCell::new(IVec3::ZERO),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+        GlobalTransform::default(),
+    ));
+}
+```
+The plugin rewrites `Transform` propagation so entities stay centered around the origin while preserving absolute `GridCell` indices for simulation logic.
+
+## Benefits for Planetary CA
+- Integer grids let you address voxels across planetary scales without precision loss; CA updates can operate on `(grid_cell, local_pos)` pairs, while rendering works in f32 space relative to the floating origin.
+- Spatial hash (`GridHash`) allows rapid neighbor queries across chunk boundaries, useful for diffusing CA states and synchronizing fracture fronts.
+- Compatible with `oktree` or chunked voxel storage: treat each chunk as a `GridCell` child and maintain absolute indexing for streaming.
+
+## Considerations
+- You must manage recentering frequency: `FloatingOrigin` systems recenter when the tracked entity leaves a cell; ensure CA job scheduling tolerates the momentary `Transform` update.
+- Physics/gravity require custom integration with Big Space coordinates; align gravitational acceleration toward the planetary center expressed in high-precision grid space, then convert to local `Transform` for rendering.
+- Network replication or save files should serialize `GridCell` + local transform rather than raw floats to avoid drift.

--- a/docs/building_blocks_research.md
+++ b/docs/building_blocks_research.md
@@ -1,0 +1,36 @@
+# Building Blocks Crate Assessment
+
+## Overview
+- **Repository**: https://github.com/bonsairobo/building-blocks
+- **Status**: Maintenance mode; author recommends migrating to smaller successor crates focused on slice-based APIs backed by the feldspar project.
+- **Scope**: Provides voxel-focused data structures, LOD clipmaps, chunk storage, procedural sampling helpers, greedy and Surface Nets meshing, chunk databases with compression, and spatial queries.
+
+## Strengths
+- Ready-made chunk trees with split/merge events for clipmap-driven LOD and streaming.
+- Multiple meshing algorithms (greedy, Surface Nets) usable on CPU workers with configurable voxel sizes.
+- `ChunkDb` abstraction for compressed persistence with `sled`, supporting LZ4/Snappy backends and configurable features.
+- Rich documentation and examples covering sampling SDFs, chunk paging, and clipmap management.
+
+## Weaknesses / Risks
+- Maintenance hiatus makes long-term support uncertain; upstream recommends new crates in the author's "my-stack" list instead.
+- API centered around bespoke `Array`/`Extent` types may conflict with existing ECS-centric storage, leading to conversion overhead.
+- Heavy dependency surface (meshing, compression, pathfinding) when enabling default features; requires careful feature gating for WASM or minimal builds.
+
+## Applicability to Planetary CA MVP
+- **Chunk storage & paging**: `ChunkTree` could prototype clipmap paging before custom solution, but lack of maintenance makes it risky for core MVP. Favor integrating concepts rather than depending on crate binaries.
+- **Meshing**: Greedy meshing implementation can serve as reference for GPU/compute rewrite, but shipping dependency into MVP is optional.
+- **Compression**: `ChunkDb` demonstrates chunk diff persistence; evaluate porting design to in-house storage or using smaller crates that remain maintained.
+
+## Integration Notes
+- If prototyping with the crate, disable default features and enable only required modules to limit dependencies:
+  ```toml
+  [dependencies]
+  building-blocks = { version = "0.7", default-features = false, features = [
+      "array", "chunk_map", "chunk_tree", "lod", "mesh"
+  ] }
+  ```
+- Convert between `building_blocks::core::Point3i` and Bevy `IVec3` through `.into()` when the "glam" feature is enabled.
+- Run meshing on worker threads and upload results to Bevy using `RenderAsset` implementations to keep render graph decoupled from CPU mesher.
+
+## Recommendation
+Treat Building Blocks as a design reference and optional prototype helper. For the MVP planetary CA, replicate core ideas (clipmaps, chunk compression) with maintained, ECS-friendly libraries or in-house implementations to avoid lock-in to an unmaintained dependency.

--- a/docs/ilattice_research.md
+++ b/docs/ilattice_research.md
@@ -1,0 +1,42 @@
+# ilattice Crate Assessment
+
+## Overview
+- **Repository**: https://github.com/bonsairobo/ilattice-rs
+- **Purpose**: Generic math utilities for integer lattices (regular 2D/3D grids) with tight integration with `glam` vector types.
+- **Core Features**:
+  - Trait-based abstractions for integer and real vector math (`IntegerVector`, extent utilities, morton encoding).
+  - Re-exported `glam` types for convenience, providing `IVec2/3`, `UVec2/3`, and `Vec2/3` implementations.
+  - Helpers for Morton (Z-curve) indexing to linearize 3D grids for cache-friendly storage.
+
+## Strengths
+- Minimal dependency footprint and actively published (0.4.0) with focused scope.
+- Drop-in conversions for `glam` types simplify interoperability with Bevy transforms and chunk coordinates.
+- Provides generic traits usable in custom data structures, enabling compile-time dimension configuration and SIMD-friendly math.
+
+## Weaknesses / Risks
+- Does not include storage or meshing primitives; only math helpers. Needs pairing with custom chunk storage.
+- Limited documentation on integration patterns beyond lattice math; requires in-house design for chunk streaming.
+
+## Applicability to Planetary CA MVP
+- Useful for Morton indexing of chunk IDs and sub-voxel coordinates when building cache-friendly structures or GPU-friendly buffers.
+- Can underpin custom clipmap/octree indexing without adopting large frameworks.
+- Lightweight enough to include directly in MVP for coordinate math consistency alongside `big_space` high-precision transforms.
+
+## Integration Notes
+- Add dependency:
+  ```toml
+  [dependencies]
+  ilattice = { version = "0.4", features = ["glam"] }
+  ```
+- Use Morton utilities for chunk atlas packing:
+  ```rust
+  use ilattice::morton::{MortonEncoder3D, morton_decode3d};
+
+  let encoder = MortonEncoder3D::default();
+  let morton_index = encoder.encode(IVec3::new(x, y, z));
+  let coords = morton_decode3d(morton_index);
+  ```
+- Combine with `big_space` grid cells by storing `MortonKey` within chunk components for deterministic ordering during streaming.
+
+## Recommendation
+Adopt `ilattice` in the MVP to standardize integer lattice math, Morton ordering, and conversions with `glam`. Its focused feature set complements custom chunk storage without imposing heavy architecture constraints.

--- a/docs/oktree_research.md
+++ b/docs/oktree_research.md
@@ -1,0 +1,39 @@
+# Oaktree (`oktree`) Research
+
+## Crate Overview
+- **Crate**: [`oktree`](https://crates.io/crates/oktree) v0.4.1
+- **Purpose**: High-performance, pointer-free sparse voxel octree with optional Bevy integration feature flag.
+- **Key design points**:
+  - Avoids smart pointers to maximize cache locality and performance, instead using contiguous buffers and indices for nodes ([docs.rs reference](https://docs.rs/oktree/0.4.1/oktree/)).
+  - Provides Bevy feature flag (`features = ["bevy"]`) to expose intersection methods and component wrappers for engine integration ([docs.rs feature list](https://docs.rs/oktree/0.4.1/oktree/#features)).
+
+## Benchmark Summary
+The published benchmark for `oktree` uses a `4096³` volume and shows the following timings on release builds (`cargo bench --all-features`) [source](https://docs.rs/oktree/0.4.1/oktree/#benchmark):
+
+| Operation | Quantity | Time |
+|-----------|----------|------|
+| Insertion | 65,536 cells | 21 ms |
+| Removal | 65,536 cells | 1.5 ms |
+| Point lookup | 65,536 searches | 12 ms |
+| Ray intersection | 4,096 rays vs 65,536 cells | 37 ms |
+| Sphere intersection | 4,096 spheres vs 65,536 cells | 8 ms |
+| Box intersection | 4,096 boxes vs 65,536 cells | 7 ms |
+
+These numbers imply ~3.1M insertions per second and ~2.8M ray tests per second on the reference hardware. For CA workloads the branch factor (8) suits sparse activation patterns (e.g., cellular surfaces or shells) rather than densely active solids.
+
+## Integration Notes
+- Initial tree construction uses `Octree::from_aabb_with_capacity(aabb, capacity)` where capacity is the maximum leaf load before subdivision; tune to control tree depth vs. branching overhead ([docs.rs usage](https://docs.rs/oktree/0.4.1/oktree/#example)).
+- Ray/sphere/box intersection helpers depend on the Bevy feature flag; enabling it adds `bevy` crate as a dependency and exports bundles for rendering debug draws.
+- The crate exposes `Octree::iter()` and neighborhood traversal utilities to stream active cells into GPU-friendly buffers for chunk meshing.
+
+## Suitability for Planetary CA
+- Works best for sparse volumes (e.g., thin atmosphere layers or crust shells). Dense planetary interiors will cause high branching depth and degrade cache performance. Combining octrees with chunked voxel bricks (e.g., `32³` dense tiles) reduces pointer chasing by limiting tree depth.
+- Node capacity is stored as `Unsigned` generics (`u8`..`u128`), enabling very deep hierarchies for huge worlds, but memory usage grows exponentially if the planet interior is densely populated.
+- In scenarios with frequent large-scale edits (splitting planet), consider hybrid approach: maintain coarse-grained `oktree` for active fracture front and offload interior to chunked arrays; leverage `oktree` for collision/visibility queries.
+
+## Alternative Structures
+- **Sparse grids with paging** (e.g., hash-map keyed chunks) offer predictable memory/performance for dense fill factors and are easier to stream to GPU.
+- **Voxel DAGs / Sparse Voxel Octrees (SVO)** are heavier to update but compress static regions better—useful for far-field read-only LOD once the CA stabilizes.
+- **Dual contouring on chunked terrain** is friendlier to incremental meshing than per-voxel ray queries; combine with compute shaders for fracture updates when splitting the planet.
+
+In summary, `oktree` is suitable for sparse, high-frequency query workloads (collisions, neighbor search) but should be combined with chunked dense storage for planetary cellular automata.

--- a/docs/scaling_strategies.md
+++ b/docs/scaling_strategies.md
@@ -1,0 +1,36 @@
+# Scaling Strategies for Planetary Cellular Automata
+
+## Engine-Level Optimizations
+- **Profile configs**: Enable dependency optimizations even in dev builds to keep Bevy responsive without losing debug assertions ([Bevy Cheatbook - Performance](https://bevy-cheatbook.github.io/pitfalls/performance.html)). Suggested `Cargo.toml` snippet:
+  ```toml
+  [profile.dev]
+  opt-level = 1
+  [profile.dev.package."*"]
+  opt-level = 3
+  ```
+- **Task scheduling**: Offload CA updates to `bevy_tasks::ComputeTaskPool` or dedicated `TaskPoolBuilder` instances; the task API supports scoped parallel iteration and work stealing ([bevy_tasks README](https://github.com/bevyengine/bevy/tree/main/crates/bevy_tasks)).
+- **System ordering**: Use `bevy::ecs::schedule::Schedule` with custom sets (e.g., `UpdateSet::Simulation`) so CA updates run before rendering recenter events from `big_space`.
+
+## Spatial Partitioning
+- Combine chunked voxel bricks (e.g., `32³` or `64³`) with higher-level spatial structures:
+  - `GridHashMap` from `big_space` for O(1) neighbor discovery across chunk boundaries.
+  - Optional `oktree` overlays for sparsely active regions (e.g., atmosphere, weather) to reduce memory footprint.
+- Maintain multi-resolution LOD chain: near-field uses dense simulation, mid-field uses aggregated chunk states (averaged or downsampled), far-field uses analytical/texture-driven approximations.
+
+## Time Dilation & Simulation Budgeting
+- Track average CA step cost (ms) and dynamically scale simulation rate when exceeding frame budget. Provide `SimulationSpeed` resource that lerps toward target `dt` to avoid abrupt slowdowns.
+- Permit "batch" updates by splitting the planet into rings or face patches updated on alternating frames; ensures consistent progress without blocking render thread.
+
+## Rendering Considerations
+- Use instanced meshes or compute-driven mesh generation for active voxels instead of individual entities; mesh generation should operate per chunk.
+- Implement view-dependent LOD: skip CA meshing for chunks outside a camera-dependent radius, fallback to impostor textures or GPU-generated spheres.
+- Employ async GPU uploads (via `RenderAssetUsages::REQUIRES_ASSET_LOADING`) to stream chunk meshes without stalling the main thread.
+
+## Persistence & Streaming
+- Serialize CA state per chunk using `GridCell` indices plus local dense arrays for compatibility with `big_space` coordinates.
+- Implement background streaming threads that prefetch neighbor chunks based on camera velocity and gravity vector, warming caches before the player arrives.
+
+## Failure Modes & Mitigations
+- **Floating origin jitter**: recenter events can cause physics jitter; double-buffer CA-to-physics transforms and apply smoothing.
+- **GPU memory blow-up**: For a 16 GB GPU, reserve <12 GB for chunk meshes/textures to leave headroom for swapchain; this equates to ~12k active chunks at 1 MB each. Use compression or procedural regeneration for far-field data.
+- **Workload spikes when splitting planets**: precompute fracture planes and reuse mesh topology where possible; stream cut geometry via compute shaders to keep CPU cost bounded.


### PR DESCRIPTION
## Summary
- expand the roadmap with ilattice-based Morton ordering guidance and a plan to avoid shipping building-blocks in the MVP
- document research findings on the building-blocks crate, including risks and prototype-only usage guidance
- add an ilattice research note covering features, integration examples, and justification for adoption

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68d8ba17b8fc8328af2b3002fe5a4302