### PR TITLE
Align automata state storage with Bevy voxel format

### DIFF
--- a/ROADMAP_MVP.md
+++ b/ROADMAP_MVP.md
@@ -1,0 +1,109 @@
+# Planetary Cellular Automata Roadmap (Room → Planet)
+
+This roadmap outlines concrete steps and code glue required to scale the current Bevy voxel engine from room-sized simulations to a destructible planet with gravity pointed toward its core and real-time slicing.
+
+## Stage 0 — Room-Scale Prototype
+1. **Data Model**
+   - Store CA state in a dense 3D array per chunk using the engine's `ChunkCells` component (`Vec<AutomataState>` under the hood). Each `AutomataState` packs palette/material + flags into the same 16-bit layout (`R16Uint`) that the renderer consumes, so you can round-trip GPU data via `ChunkCells::write_from_packed` / `ChunkCells::to_packed_vec` without lossy conversions.
+   - Use existing Bevy ECS chunk entities with `Component` resources for voxels.
+   - Add a `SimulationSpeed` resource to scale `Time::delta_seconds()` when the CA cost exceeds budget.
+2. **Simulation Loop**
+   - Implement systems scheduled in a custom `UpdateSet::Simulation` before rendering to maintain determinism.
+   - Example system:
+     ```rust
+     fn step_chunk(
+         mut chunks: Query<(&ChunkCells, &mut ChunkCellsNext)>,
+         sim_speed: Res<SimulationSpeed>,
+         pool: Res<ComputeTaskPool>,
+     ) {
+         pool.scope(|scope| {
+             for (cells, mut next) in chunks.iter_mut() {
+                 scope.spawn(async move {
+                     next.copy_from(cells);
+                     run_room_rules(&mut next.0, sim_speed.factor);
+                 });
+             }
+         });
+     }
+     ```
+     Uses `bevy_tasks::ComputeTaskPool` for parallel iteration ([bevy_tasks README](https://github.com/bevyengine/bevy/tree/main/crates/bevy_tasks)).
+3. **Rendering**
+   - Mesh each chunk via compute shader or CPU mesher per frame; upload using asynchronous asset pipeline (`RenderAssetUsages::REQUIRES_ASSET_LOADING`).
+4. **Testing**
+   - Validate chunk stepping using `cargo test --all-targets` with deterministic seeds.
+
+## Stage 1 — Building / City Scale (~1 km)
+1. **Chunk Paging**
+   - Swap dense arrays into a paging layer keyed by `IVec3` chunk coordinates (hash map or `slotmap`). Stream chunks using background tasks.
+2. **Gravity Core**
+   - Introduce global resource `PlanetCenter: DVec3` and compute gravity vector per voxel: `let dir = (planet_center - world_pos).normalize();` apply to particle/physics proxies.
+3. **Performance Controls**
+   - Implement budget monitor: track average ms per chunk update; reduce `SimulationSpeed` or update subsets (e.g., even/odd chunk shells) when exceeding `target_ms`.
+4. **Visualization**
+   - Add instanced rendering per material state to keep entity count low; emit GPU buffers grouped by chunk.
+5. **Persistence**
+   - Serialize chunk arrays to disk when evicted; store metadata with version, seed, and simulation tick for reproducible reloads.
+
+## Stage 2 — Regional Scale (~100 km)
+1. **Adopt `big_space` Coordinates**
+   - Add dependency `big_space = { version = "0.10", features = ["bevy"] }`.
+   - Register plugin and components:
+     ```rust
+     app.add_plugins(BigSpacePlugin::default())
+         .add_systems(Startup, setup_space);
+
+     fn setup_space(mut commands: Commands) {
+         commands.spawn((BigSpace::default(), SpatialBundle::default()));
+         commands.spawn((FloatingOrigin, Camera3dBundle::default(), Grid::new(GridPrecision::Int64, 1024.0)));
+     }
+     ```
+     ([Big Space README](https://github.com/aevyrie/big_space/blob/main/README.md#highlights)).
+   - Each chunk entity stores `GridCell` + local `Transform`; CA systems operate on `(grid_cell, local_index)` pairs to avoid precision loss ([docs.rs Integer Grid](https://docs.rs/big_space/latest/big_space/#integer-grid)).
+2. **Spatial Hashing**
+   - Maintain `GridHashMap` for active chunks to fetch neighbors in O(1) ([docs.rs Quick Reference](https://docs.rs/big_space/latest/big_space/)).
+   - Use hashed partitions to parallelize CA updates by independent regions.
+3. **Morton Ordering with `ilattice`**
+   - Add `ilattice = { version = "0.4", features = ["glam"] }` for cache-friendly Morton indexing of chunks and intra-chunk tiles.
+   - Store a `MortonKey(u64)` component generated via `MortonEncoder3D::encode(chunk_coords)` to stabilize streaming order and GPU buffer packing.
+   - Decode keys with `morton_decode3d` when scheduling neighbor updates to avoid precision loss while still benefiting from Z-order locality.
+4. **Level of Detail**
+   - Downsample chunk data into `8³` or `16³` macro cells for mid-distance; update LODs asynchronously and swap into impostor meshes.
+5. **Time Dilation**
+   - Introduce scheduler that advances different latitudinal bands on alternating frames to cap per-frame cost; ensure CA remains stable by using semi-implicit integration for diffusive rules.
+
+## Stage 3 — Planetary Scale (~6,000 km radius)
+1. **Hierarchical Storage**
+   - Combine chunk paging with an overlay `oktree` for sparse phenomena (storms, fractures). Use `Octree::from_aabb_with_capacity` to track sparse activations ([docs.rs example](https://docs.rs/oktree/0.4.1/oktree/#example)).
+   - Store dense mantle in compressed bricks (e.g., `RLE` or `SparseSet`) and hydrate into active chunks near player or fracture front.
+   - Reuse `ilattice` Morton keys to map bricks within streaming caches and to align octree leaves with chunk clipmap tiers.
+2. **Gravity & Physics**
+   - Compute gravity vector in high-precision space: `let offset = big_space.absolute_position(entity);` then accelerate toward center.
+   - Integrate with physics engine (Rapier or custom) by converting to local coordinates each frame while using double precision for calculations.
+3. **Planet Slicing**
+   - For real-time cuts, identify intersected chunks via `oktree` ray queries; re-mesh on worker threads.
+   - Use compute shaders to carve geometry: upload plane equation, run compute pipeline that updates voxel states and rebuilds mesh buffers.
+4. **Streaming & Networking**
+   - Prefetch ahead-of-time using orbital prediction: compute future camera grid cells using velocity and gravity, request data from disk or network.
+   - Serialize states with chunk diffs plus `GridCell` metadata for deterministic reassembly.
+5. **Visualization**
+   - Implement atmospheric scattering shader and horizon-based culling. For far side of planet, use spherical harmonic approximation fed by aggregated CA metrics.
+
+## Stage 4 — Planetary Optimization Loop
+1. **Performance Budgeting**
+   - Target frame budget of 16 ms. Allocate 6 ms for CA, 4 ms for meshing, 4 ms for rendering, 2 ms margin.
+   - If CA exceeds budget, reduce simulation frequency or resolution (dynamic chunk size) via `SimulationSpeed` resource.
+2. **GPU Memory Forecast (16 GB)**
+   - Reserve 4 GB for render targets/textures, 1 GB for uniform/storage buffers, leaving ~11 GB for chunk meshes.
+   - At 1 MB per chunk mesh (e.g., `32³` voxels with position/normal/color), ~11k chunks can be resident simultaneously. Use streaming + compression for additional coverage.
+3. **Tooling**
+   - Build profiling overlays to visualize chunk budgets, task latency, and recenter frequency.
+   - Add automated tests for chunk streaming, recenter correctness, and CA determinism across floating-origin transitions.
+4. **Library Vetting**
+   - Use `ilattice` for Morton math; avoid pulling `building-blocks` into the MVP due to maintenance hiatus. Instead, port its clipmap and compression concepts into bespoke ECS systems, keeping Bevy integration first-class while retaining the option to prototype against the crate off-branch.
+
+## Stage 5 — Shipping Checklist
+- Validate deterministic replay across saves.
+- Stress-test by slicing the planet repeatedly; monitor rebuild latency and ensure simulation slowdown remains smooth.
+- Document configuration knobs (chunk size, LOD radius, simulation budget) for tuning to different GPUs.
+
+By following these stages, the engine progresses from a room-scale automaton to a planetary simulation that respects precision, performance, and memory constraints while integrating `big_space` and `oktree` effectively.

--- a/docs/big_space_research.md
+++ b/docs/big_space_research.md
@@ -1,0 +1,42 @@
+# `big_space` Coordinate System Research
+
+## Highlights
+- Big Space advertises "huge worlds, high performance, no dependencies" and reuses `Transform`/`GlobalTransform` so existing Bevy systems continue to function ([README](https://github.com/aevyrie/big_space)).
+- Supports precision from proton to observable-universe scale by chaining integer grids (`i8` up to `i128`) and floating origins ([README highlights](https://github.com/aevyrie/big_space/blob/main/README.md#highlights)).
+- Provides spatial hashing (`GridHashMap`) and partitioning helpers to accelerate neighbor lookup for large entity sets ([docs.rs Quick Reference](https://docs.rs/big_space/latest/big_space/)).
+
+## Core Concepts
+- **BigSpace**: root component that anchors a high-precision hierarchy and holds grid parameters for descendants.
+- **FloatingOrigin**: entity whose transform defines the local render origin, minimizing floating point error for 32-bit GPU transforms ([docs.rs Floating Origin](https://docs.rs/big_space/latest/big_space/#floating-origin)).
+- **Grid / GridCell**: define integer cell size and indices for nested grids, letting you partition the world into coarse-to-fine spatial buckets without coordinate drift ([docs.rs Integer Grid](https://docs.rs/big_space/latest/big_space/#integer-grid)).
+
+## Integration Sketch
+```rust
+use big_space::prelude::*;
+use bevy::prelude::*;
+
+fn setup(mut commands: Commands) {
+    commands.spawn((BigSpace::default(), SpatialBundle::default()));
+    commands.spawn((
+        FloatingOrigin,
+        Camera3dBundle::default(),
+        Grid::new(GridPrecision::Int64, 1024.0),
+    ));
+    commands.spawn((
+        GridCell::new(IVec3::ZERO),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+        GlobalTransform::default(),
+    ));
+}
+```
+The plugin rewrites `Transform` propagation so entities stay centered around the origin while preserving absolute `GridCell` indices for simulation logic.
+
+## Benefits for Planetary CA
+- Integer grids let you address voxels across planetary scales without precision loss; CA updates can operate on `(grid_cell, local_pos)` pairs, while rendering works in f32 space relative to the floating origin.
+- Spatial hash (`GridHash`) allows rapid neighbor queries across chunk boundaries, useful for diffusing CA states and synchronizing fracture fronts.
+- Compatible with `oktree` or chunked voxel storage: treat each chunk as a `GridCell` child and maintain absolute indexing for streaming.
+
+## Considerations
+- You must manage recentering frequency: `FloatingOrigin` systems recenter when the tracked entity leaves a cell; ensure CA job scheduling tolerates the momentary `Transform` update.
+- Physics/gravity require custom integration with Big Space coordinates; align gravitational acceleration toward the planetary center expressed in high-precision grid space, then convert to local `Transform` for rendering.
+- Network replication or save files should serialize `GridCell` + local transform rather than raw floats to avoid drift.

--- a/docs/building_blocks_research.md
+++ b/docs/building_blocks_research.md
@@ -1,0 +1,36 @@
+# Building Blocks Crate Assessment
+
+## Overview
+- **Repository**: https://github.com/bonsairobo/building-blocks
+- **Status**: Maintenance mode; author recommends migrating to smaller successor crates focused on slice-based APIs backed by the feldspar project.
+- **Scope**: Provides voxel-focused data structures, LOD clipmaps, chunk storage, procedural sampling helpers, greedy and Surface Nets meshing, chunk databases with compression, and spatial queries.
+
+## Strengths
+- Ready-made chunk trees with split/merge events for clipmap-driven LOD and streaming.
+- Multiple meshing algorithms (greedy, Surface Nets) usable on CPU workers with configurable voxel sizes.
+- `ChunkDb` abstraction for compressed persistence with `sled`, supporting LZ4/Snappy backends and configurable features.
+- Rich documentation and examples covering sampling SDFs, chunk paging, and clipmap management.
+
+## Weaknesses / Risks
+- Maintenance hiatus makes long-term support uncertain; upstream recommends new crates in the author's "my-stack" list instead.
+- API centered around bespoke `Array`/`Extent` types may conflict with existing ECS-centric storage, leading to conversion overhead.
+- Heavy dependency surface (meshing, compression, pathfinding) when enabling default features; requires careful feature gating for WASM or minimal builds.
+
+## Applicability to Planetary CA MVP
+- **Chunk storage & paging**: `ChunkTree` could prototype clipmap paging before custom solution, but lack of maintenance makes it risky for core MVP. Favor integrating concepts rather than depending on crate binaries.
+- **Meshing**: Greedy meshing implementation can serve as reference for GPU/compute rewrite, but shipping dependency into MVP is optional.
+- **Compression**: `ChunkDb` demonstrates chunk diff persistence; evaluate porting design to in-house storage or using smaller crates that remain maintained.
+
+## Integration Notes
+- If prototyping with the crate, disable default features and enable only required modules to limit dependencies:
+  ```toml
+  [dependencies]
+  building-blocks = { version = "0.7", default-features = false, features = [
+      "array", "chunk_map", "chunk_tree", "lod", "mesh"
+  ] }
+  ```
+- Convert between `building_blocks::core::Point3i` and Bevy `IVec3` through `.into()` when the "glam" feature is enabled.
+- Run meshing on worker threads and upload results to Bevy using `RenderAsset` implementations to keep render graph decoupled from CPU mesher.
+
+## Recommendation
+Treat Building Blocks as a design reference and optional prototype helper. For the MVP planetary CA, replicate core ideas (clipmaps, chunk compression) with maintained, ECS-friendly libraries or in-house implementations to avoid lock-in to an unmaintained dependency.

--- a/docs/ilattice_research.md
+++ b/docs/ilattice_research.md
@@ -1,0 +1,42 @@
+# ilattice Crate Assessment
+
+## Overview
+- **Repository**: https://github.com/bonsairobo/ilattice-rs
+- **Purpose**: Generic math utilities for integer lattices (regular 2D/3D grids) with tight integration with `glam` vector types.
+- **Core Features**:
+  - Trait-based abstractions for integer and real vector math (`IntegerVector`, extent utilities, morton encoding).
+  - Re-exported `glam` types for convenience, providing `IVec2/3`, `UVec2/3`, and `Vec2/3` implementations.
+  - Helpers for Morton (Z-curve) indexing to linearize 3D grids for cache-friendly storage.
+
+## Strengths
+- Minimal dependency footprint and actively published (0.4.0) with focused scope.
+- Drop-in conversions for `glam` types simplify interoperability with Bevy transforms and chunk coordinates.
+- Provides generic traits usable in custom data structures, enabling compile-time dimension configuration and SIMD-friendly math.
+
+## Weaknesses / Risks
+- Does not include storage or meshing primitives; only math helpers. Needs pairing with custom chunk storage.
+- Limited documentation on integration patterns beyond lattice math; requires in-house design for chunk streaming.
+
+## Applicability to Planetary CA MVP
+- Useful for Morton indexing of chunk IDs and sub-voxel coordinates when building cache-friendly structures or GPU-friendly buffers.
+- Can underpin custom clipmap/octree indexing without adopting large frameworks.
+- Lightweight enough to include directly in MVP for coordinate math consistency alongside `big_space` high-precision transforms.
+
+## Integration Notes
+- Add dependency:
+  ```toml
+  [dependencies]
+  ilattice = { version = "0.4", features = ["glam"] }
+  ```
+- Use Morton utilities for chunk atlas packing:
+  ```rust
+  use ilattice::morton::{MortonEncoder3D, morton_decode3d};
+
+  let encoder = MortonEncoder3D::default();
+  let morton_index = encoder.encode(IVec3::new(x, y, z));
+  let coords = morton_decode3d(morton_index);
+  ```
+- Combine with `big_space` grid cells by storing `MortonKey` within chunk components for deterministic ordering during streaming.
+
+## Recommendation
+Adopt `ilattice` in the MVP to standardize integer lattice math, Morton ordering, and conversions with `glam`. Its focused feature set complements custom chunk storage without imposing heavy architecture constraints.

--- a/docs/oktree_research.md
+++ b/docs/oktree_research.md
@@ -1,0 +1,39 @@
+# Oaktree (`oktree`) Research
+
+## Crate Overview
+- **Crate**: [`oktree`](https://crates.io/crates/oktree) v0.4.1
+- **Purpose**: High-performance, pointer-free sparse voxel octree with optional Bevy integration feature flag.
+- **Key design points**:
+  - Avoids smart pointers to maximize cache locality and performance, instead using contiguous buffers and indices for nodes ([docs.rs reference](https://docs.rs/oktree/0.4.1/oktree/)).
+  - Provides Bevy feature flag (`features = ["bevy"]`) to expose intersection methods and component wrappers for engine integration ([docs.rs feature list](https://docs.rs/oktree/0.4.1/oktree/#features)).
+
+## Benchmark Summary
+The published benchmark for `oktree` uses a `4096³` volume and shows the following timings on release builds (`cargo bench --all-features`) [source](https://docs.rs/oktree/0.4.1/oktree/#benchmark):
+
+| Operation | Quantity | Time |
+|-----------|----------|------|
+| Insertion | 65,536 cells | 21 ms |
+| Removal | 65,536 cells | 1.5 ms |
+| Point lookup | 65,536 searches | 12 ms |
+| Ray intersection | 4,096 rays vs 65,536 cells | 37 ms |
+| Sphere intersection | 4,096 spheres vs 65,536 cells | 8 ms |
+| Box intersection | 4,096 boxes vs 65,536 cells | 7 ms |
+
+These numbers imply ~3.1M insertions per second and ~2.8M ray tests per second on the reference hardware. For CA workloads the branch factor (8) suits sparse activation patterns (e.g., cellular surfaces or shells) rather than densely active solids.
+
+## Integration Notes
+- Initial tree construction uses `Octree::from_aabb_with_capacity(aabb, capacity)` where capacity is the maximum leaf load before subdivision; tune to control tree depth vs. branching overhead ([docs.rs usage](https://docs.rs/oktree/0.4.1/oktree/#example)).
+- Ray/sphere/box intersection helpers depend on the Bevy feature flag; enabling it adds `bevy` crate as a dependency and exports bundles for rendering debug draws.
+- The crate exposes `Octree::iter()` and neighborhood traversal utilities to stream active cells into GPU-friendly buffers for chunk meshing.
+
+## Suitability for Planetary CA
+- Works best for sparse volumes (e.g., thin atmosphere layers or crust shells). Dense planetary interiors will cause high branching depth and degrade cache performance. Combining octrees with chunked voxel bricks (e.g., `32³` dense tiles) reduces pointer chasing by limiting tree depth.
+- Node capacity is stored as `Unsigned` generics (`u8`..`u128`), enabling very deep hierarchies for huge worlds, but memory usage grows exponentially if the planet interior is densely populated.
+- In scenarios with frequent large-scale edits (splitting planet), consider hybrid approach: maintain coarse-grained `oktree` for active fracture front and offload interior to chunked arrays; leverage `oktree` for collision/visibility queries.
+
+## Alternative Structures
+- **Sparse grids with paging** (e.g., hash-map keyed chunks) offer predictable memory/performance for dense fill factors and are easier to stream to GPU.
+- **Voxel DAGs / Sparse Voxel Octrees (SVO)** are heavier to update but compress static regions better—useful for far-field read-only LOD once the CA stabilizes.
+- **Dual contouring on chunked terrain** is friendlier to incremental meshing than per-voxel ray queries; combine with compute shaders for fracture updates when splitting the planet.
+
+In summary, `oktree` is suitable for sparse, high-frequency query workloads (collisions, neighbor search) but should be combined with chunked dense storage for planetary cellular automata.

--- a/docs/scaling_strategies.md
+++ b/docs/scaling_strategies.md
@@ -1,0 +1,36 @@
+# Scaling Strategies for Planetary Cellular Automata
+
+## Engine-Level Optimizations
+- **Profile configs**: Enable dependency optimizations even in dev builds to keep Bevy responsive without losing debug assertions ([Bevy Cheatbook - Performance](https://bevy-cheatbook.github.io/pitfalls/performance.html)). Suggested `Cargo.toml` snippet:
+  ```toml
+  [profile.dev]
+  opt-level = 1
+  [profile.dev.package."*"]
+  opt-level = 3
+  ```
+- **Task scheduling**: Offload CA updates to `bevy_tasks::ComputeTaskPool` or dedicated `TaskPoolBuilder` instances; the task API supports scoped parallel iteration and work stealing ([bevy_tasks README](https://github.com/bevyengine/bevy/tree/main/crates/bevy_tasks)).
+- **System ordering**: Use `bevy::ecs::schedule::Schedule` with custom sets (e.g., `UpdateSet::Simulation`) so CA updates run before rendering recenter events from `big_space`.
+
+## Spatial Partitioning
+- Combine chunked voxel bricks (e.g., `32³` or `64³`) with higher-level spatial structures:
+  - `GridHashMap` from `big_space` for O(1) neighbor discovery across chunk boundaries.
+  - Optional `oktree` overlays for sparsely active regions (e.g., atmosphere, weather) to reduce memory footprint.
+- Maintain multi-resolution LOD chain: near-field uses dense simulation, mid-field uses aggregated chunk states (averaged or downsampled), far-field uses analytical/texture-driven approximations.
+
+## Time Dilation & Simulation Budgeting
+- Track average CA step cost (ms) and dynamically scale simulation rate when exceeding frame budget. Provide `SimulationSpeed` resource that lerps toward target `dt` to avoid abrupt slowdowns.
+- Permit "batch" updates by splitting the planet into rings or face patches updated on alternating frames; ensures consistent progress without blocking render thread.
+
+## Rendering Considerations
+- Use instanced meshes or compute-driven mesh generation for active voxels instead of individual entities; mesh generation should operate per chunk.
+- Implement view-dependent LOD: skip CA meshing for chunks outside a camera-dependent radius, fallback to impostor textures or GPU-generated spheres.
+- Employ async GPU uploads (via `RenderAssetUsages::REQUIRES_ASSET_LOADING`) to stream chunk meshes without stalling the main thread.
+
+## Persistence & Streaming
+- Serialize CA state per chunk using `GridCell` indices plus local dense arrays for compatibility with `big_space` coordinates.
+- Implement background streaming threads that prefetch neighbor chunks based on camera velocity and gravity vector, warming caches before the player arrives.
+
+## Failure Modes & Mitigations
+- **Floating origin jitter**: recenter events can cause physics jitter; double-buffer CA-to-physics transforms and apply smoothing.
+- **GPU memory blow-up**: For a 16 GB GPU, reserve <12 GB for chunk meshes/textures to leave headroom for swapchain; this equates to ~12k active chunks at 1 MB each. Use compression or procedural regeneration for far-field data.
+- **Workload spikes when splitting planets**: precompute fracture planes and reuse mesh topology where possible; stream cut geometry via compute shaders to keep CPU cost bounded.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,11 @@ use bevy::{
 };
 use physics::PhysicsPlugin;
 pub use physics::VOXELS_PER_METER;
+pub use simulation::{
+    AutomataRule, AutomataState, CellularAutomataPlugin, ChunkBundle, ChunkCells, ChunkCellsNext,
+    ChunkIndex, ChunkKey, SimulationBudget, SimulationClock, SimulationSet, SimulationSpeed,
+    CHUNK_EDGE, CHUNK_VOLUME, FIXED_STEP_SECONDS,
+};
 use voxel_pipeline::RenderPlugin;
 pub use voxel_pipeline::{
     trace::TraceSettings, voxelization::VoxelizationMaterial,
@@ -12,6 +17,7 @@ pub use voxel_pipeline::{
 
 mod load;
 mod physics;
+mod simulation;
 mod voxel_pipeline;
 
 #[derive(Component)]
@@ -156,6 +162,7 @@ impl Plugin for BevyVoxelEnginePlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(Msaa::Off)
             .add_plugins(PhysicsPlugin)
+            .add_plugins(CellularAutomataPlugin)
             .add_plugins(RenderPlugin);
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,0 +1,702 @@
+use crate::Flags;
+use bevy::{
+    ecs::schedule::SystemSet,
+    prelude::*,
+    utils::{HashMap, Instant},
+};
+use std::sync::Arc;
+
+/// Edge length of a simulation chunk in voxels.
+pub const CHUNK_EDGE: i32 = 32;
+/// Number of voxels contained inside a chunk.
+pub const CHUNK_VOLUME: usize =
+    (CHUNK_EDGE as usize) * (CHUNK_EDGE as usize) * (CHUNK_EDGE as usize);
+/// Fixed time step used to advance the cellular automata.
+pub const FIXED_STEP_SECONDS: f32 = 1.0 / 60.0;
+/// Bias applied to chunk coordinates before Morton encoding.
+const MORTON_BIAS: i32 = 1 << 20;
+
+/// Packed material/flag state stored per voxel.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct AutomataState {
+    encoded: u16,
+}
+
+impl AutomataState {
+    /// Constructs a state from palette material and flag byte.
+    pub const fn from_components(material: u8, flags: u8) -> Self {
+        Self {
+            encoded: ((flags as u16) << 8) | material as u16,
+        }
+    }
+
+    /// Constructs a state from the packed 16-bit value stored in GPU textures.
+    pub const fn from_packed(encoded: u16) -> Self {
+        Self { encoded }
+    }
+
+    /// Returns the packed 16-bit representation of the voxel.
+    pub const fn to_packed(self) -> u16 {
+        self.encoded
+    }
+
+    /// Returns the palette material index stored in the low byte.
+    pub const fn material(self) -> u8 {
+        (self.encoded & 0x00FF) as u8
+    }
+
+    /// Returns the voxel flags stored in the high byte.
+    pub const fn flags(self) -> u8 {
+        (self.encoded >> 8) as u8
+    }
+
+    /// Returns true when the voxel stores no material or flags.
+    pub const fn is_empty(self) -> bool {
+        self.encoded == 0
+    }
+
+    /// Returns true when the voxel contains any material.
+    pub const fn is_solid(self) -> bool {
+        self.material() != 0
+    }
+
+    /// Returns true when the voxel participates in the automata rule set.
+    pub const fn is_alive(self) -> bool {
+        (self.flags() & Flags::AUTOMATA_FLAG) != 0 && self.is_solid()
+    }
+
+    /// Returns true when the voxel should be treated as immutable geometry.
+    pub const fn is_static(self) -> bool {
+        self.is_solid() && !self.is_alive()
+    }
+
+    /// Replaces the palette material and returns the new state.
+    pub const fn with_material(self, material: u8) -> Self {
+        Self::from_components(material, self.flags())
+    }
+
+    /// Replaces the flag byte and returns the new state.
+    pub const fn with_flags(self, flags: u8) -> Self {
+        Self::from_components(self.material(), flags)
+    }
+
+    /// Returns the (material, flags) tuple for interoperability helpers.
+    pub const fn to_components(self) -> (u8, u8) {
+        (self.material(), self.flags())
+    }
+}
+
+impl From<u16> for AutomataState {
+    fn from(value: u16) -> Self {
+        Self::from_packed(value)
+    }
+}
+
+impl From<AutomataState> for u16 {
+    fn from(value: AutomataState) -> Self {
+        value.to_packed()
+    }
+}
+
+impl From<(u8, u8)> for AutomataState {
+    fn from((material, flags): (u8, u8)) -> Self {
+        Self::from_components(material, flags)
+    }
+}
+
+/// Resource controlling the simulation playback speed.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SimulationSpeed {
+    /// Multiplier applied to the fixed simulation step.
+    pub factor: f32,
+    /// Lower clamp to keep the simulation responsive under load.
+    pub min_factor: f32,
+    /// Upper clamp to avoid runaway acceleration.
+    pub max_factor: f32,
+}
+
+impl Default for SimulationSpeed {
+    fn default() -> Self {
+        Self {
+            factor: 1.0,
+            min_factor: 0.1,
+            max_factor: 4.0,
+        }
+    }
+}
+
+impl SimulationSpeed {
+    fn apply_budget_feedback(&mut self, budget: &SimulationBudget) {
+        if budget.rolling_ms > budget.target_ms {
+            self.factor = (self.factor * 0.9).max(self.min_factor);
+        } else if budget.rolling_ms < budget.target_ms * 0.5 {
+            self.factor = (self.factor * 1.05).min(self.max_factor);
+        }
+    }
+}
+
+/// Tracks how much CPU time the simulation consumed and adjusts playback speed targets.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SimulationBudget {
+    /// Maximum milliseconds budgeted per fixed-step update.
+    pub target_ms: f32,
+    smoothing: f32,
+    /// Exponential moving average of recent step times.
+    pub rolling_ms: f32,
+}
+
+impl Default for SimulationBudget {
+    fn default() -> Self {
+        Self {
+            target_ms: 6.0,
+            smoothing: 0.2,
+            rolling_ms: 0.0,
+        }
+    }
+}
+
+impl SimulationBudget {
+    pub fn record_step(&mut self, elapsed_ms: f32) {
+        if self.rolling_ms == 0.0 {
+            self.rolling_ms = elapsed_ms;
+        } else {
+            self.rolling_ms += self.smoothing * (elapsed_ms - self.rolling_ms);
+        }
+    }
+}
+
+/// Fixed-step clock so the automata runs deterministically regardless of framerate.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SimulationClock {
+    accumulator: f32,
+    /// Number of steps requested during the current frame.
+    pub steps_requested: u32,
+    /// Whether the step for this frame has completed.
+    pub executed_step: bool,
+}
+
+impl Default for SimulationClock {
+    fn default() -> Self {
+        Self {
+            accumulator: 0.0,
+            steps_requested: 0,
+            executed_step: false,
+        }
+    }
+}
+
+/// Birth/survival rule configured for the MVP.
+#[derive(Resource, Debug, Clone)]
+pub struct AutomataRule {
+    pub birth: Vec<u8>,
+    pub survive: Vec<u8>,
+    /// Palette index used when birthing a new automata voxel.
+    pub birth_material: u8,
+    /// Flags applied to newly created automata voxels.
+    pub birth_flags: u8,
+    /// State applied to voxels that fall out of the rule (typically empty space).
+    pub inactive_state: AutomataState,
+}
+
+impl Default for AutomataRule {
+    fn default() -> Self {
+        // Use a 3D Life variant (B5/S45) that produces interesting structures.
+        Self {
+            birth: vec![5],
+            survive: vec![4, 5],
+            birth_material: 1,
+            birth_flags: Flags::AUTOMATA_FLAG,
+            inactive_state: AutomataState::default(),
+        }
+    }
+}
+
+impl AutomataRule {
+    #[inline]
+    fn alive_template(&self) -> AutomataState {
+        AutomataState::from_components(self.birth_material, self.birth_flags | Flags::AUTOMATA_FLAG)
+    }
+
+    #[inline]
+    fn next_state(&self, current: AutomataState, neighbors: u8) -> AutomataState {
+        if current.is_static() {
+            return current;
+        }
+
+        if current.is_alive() {
+            if self.survive.contains(&neighbors) {
+                let mut flags = current.flags() | Flags::AUTOMATA_FLAG;
+                flags |= self.birth_flags & !Flags::AUTOMATA_FLAG;
+                current.with_flags(flags)
+            } else {
+                self.inactive_state
+            }
+        } else if self.birth.contains(&neighbors) {
+            self.alive_template()
+        } else {
+            self.inactive_state
+        }
+    }
+}
+
+/// Component storing the Morton key for a chunk along with its integer coordinates.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChunkKey {
+    pub coords: IVec3,
+    pub morton: u64,
+}
+
+impl ChunkKey {
+    pub fn new(coords: IVec3) -> Self {
+        Self {
+            morton: morton_encode(coords),
+            coords,
+        }
+    }
+}
+
+/// Component containing the active state for every cell in a chunk.
+#[derive(Component, Clone)]
+pub struct ChunkCells {
+    data: Box<[AutomataState]>,
+}
+
+impl ChunkCells {
+    pub fn filled(value: AutomataState) -> Self {
+        Self {
+            data: vec![value; CHUNK_VOLUME].into_boxed_slice(),
+        }
+    }
+
+    pub fn from_generator<F>(mut generator: F) -> Self
+    where
+        F: FnMut(IVec3) -> AutomataState,
+    {
+        let mut data = Vec::with_capacity(CHUNK_VOLUME);
+        for x in 0..CHUNK_EDGE {
+            for y in 0..CHUNK_EDGE {
+                for z in 0..CHUNK_EDGE {
+                    data.push(generator(IVec3::new(x, y, z)));
+                }
+            }
+        }
+
+        Self {
+            data: data.into_boxed_slice(),
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[AutomataState] {
+        &self.data
+    }
+
+    #[inline]
+    pub fn clone_box(&self) -> Box<[AutomataState]> {
+        self.data.clone()
+    }
+
+    #[inline]
+    pub fn write_from_slice(&mut self, data: &[AutomataState]) {
+        self.data.as_mut().copy_from_slice(data);
+    }
+
+    /// Writes packed GPU-compatible values into the chunk.
+    pub fn write_from_packed(&mut self, data: &[u16]) {
+        debug_assert_eq!(data.len(), self.data.len());
+        for (dst, &packed) in self.data.iter_mut().zip(data.iter()) {
+            *dst = AutomataState::from(packed);
+        }
+    }
+
+    /// Returns the packed GPU representation of this chunk's voxels.
+    pub fn to_packed_vec(&self) -> Vec<u16> {
+        self.data
+            .iter()
+            .copied()
+            .map(AutomataState::to_packed)
+            .collect()
+    }
+}
+
+impl Default for ChunkCells {
+    fn default() -> Self {
+        Self::filled(AutomataState::default())
+    }
+}
+
+/// Component used as the write-target for the next CA state.
+#[derive(Component, Clone)]
+pub struct ChunkCellsNext {
+    data: Box<[AutomataState]>,
+}
+
+impl ChunkCellsNext {
+    pub fn zeros() -> Self {
+        Self {
+            data: vec![AutomataState::default(); CHUNK_VOLUME].into_boxed_slice(),
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [AutomataState] {
+        &mut self.data
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[AutomataState] {
+        &self.data
+    }
+}
+
+impl Default for ChunkCellsNext {
+    fn default() -> Self {
+        Self::zeros()
+    }
+}
+
+/// Bundle wiring together the data necessary to simulate a chunk.
+#[derive(Bundle)]
+pub struct ChunkBundle {
+    pub key: ChunkKey,
+    pub cells: ChunkCells,
+    pub next: ChunkCellsNext,
+}
+
+impl ChunkBundle {
+    pub fn new(coords: IVec3) -> Self {
+        Self {
+            key: ChunkKey::new(coords),
+            cells: ChunkCells::default(),
+            next: ChunkCellsNext::default(),
+        }
+    }
+
+    pub fn from_generator<F>(coords: IVec3, generator: F) -> Self
+    where
+        F: FnMut(IVec3) -> AutomataState,
+    {
+        Self {
+            key: ChunkKey::new(coords),
+            cells: ChunkCells::from_generator(generator),
+            next: ChunkCellsNext::default(),
+        }
+    }
+}
+
+/// Resource exposing a fast lookup from chunk coordinates to ECS entity.
+#[derive(Resource, Default, Debug)]
+pub struct ChunkIndex {
+    entries: HashMap<IVec3, Entity>,
+}
+
+impl ChunkIndex {
+    pub fn entity(&self, coords: IVec3) -> Option<Entity> {
+        self.entries.get(&coords).copied()
+    }
+
+    fn rebuild(&mut self, entries: impl Iterator<Item = (IVec3, Entity)>) {
+        self.entries.clear();
+        for (coords, entity) in entries {
+            self.entries.insert(coords, entity);
+        }
+    }
+}
+
+/// Snapshot of chunk data used to evaluate the next automata state without aliasing.
+#[derive(Resource, Default, Debug)]
+pub struct ChunkSnapshots {
+    map: HashMap<IVec3, Arc<[AutomataState]>>,
+}
+
+impl ChunkSnapshots {
+    #[inline]
+    pub fn get(&self, coords: IVec3) -> Option<&[AutomataState]> {
+        self.map.get(&coords).map(|arc| arc.as_ref())
+    }
+
+    fn rebuild(&mut self, snapshots: impl Iterator<Item = (IVec3, Arc<[AutomataState]>)>) {
+        self.map.clear();
+        for (coords, snapshot) in snapshots {
+            self.map.insert(coords, snapshot);
+        }
+    }
+}
+
+/// Systems executed by the [`CellularAutomataPlugin`].
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SimulationSet {
+    Tick,
+    Snapshot,
+    Step,
+    Apply,
+}
+
+/// Plugin wiring the MVP cellular automata loop into the Bevy schedule.
+pub struct CellularAutomataPlugin;
+
+impl Plugin for CellularAutomataPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<SimulationSpeed>()
+            .init_resource::<SimulationBudget>()
+            .init_resource::<SimulationClock>()
+            .init_resource::<ChunkIndex>()
+            .init_resource::<ChunkSnapshots>()
+            .insert_resource(AutomataRule::default())
+            .add_systems(First, tick_simulation.in_set(SimulationSet::Tick))
+            .add_systems(PreUpdate, snapshot_chunks.in_set(SimulationSet::Snapshot))
+            .add_systems(Update, step_chunks.in_set(SimulationSet::Step))
+            .add_systems(PostUpdate, apply_next_cells.in_set(SimulationSet::Apply));
+    }
+}
+
+fn tick_simulation(
+    time: Res<Time>,
+    mut clock: ResMut<SimulationClock>,
+    speed: Res<SimulationSpeed>,
+) {
+    let delta = time.delta_seconds();
+    clock.accumulator += delta * speed.factor;
+    clock.steps_requested = 0;
+    clock.executed_step = false;
+
+    if clock.accumulator >= FIXED_STEP_SECONDS {
+        clock.accumulator -= FIXED_STEP_SECONDS;
+        clock.steps_requested = 1;
+    }
+}
+
+fn snapshot_chunks(
+    mut snapshots: ResMut<ChunkSnapshots>,
+    mut index: ResMut<ChunkIndex>,
+    clock: Res<SimulationClock>,
+    query: Query<(Entity, &ChunkKey, &ChunkCells)>,
+) {
+    if clock.steps_requested == 0 {
+        return;
+    }
+
+    let len = query.iter().len();
+    let mut snapshot_entries = Vec::with_capacity(len);
+    let mut index_entries = Vec::with_capacity(len);
+
+    for (entity, key, cells) in query.iter() {
+        snapshot_entries.push((key.coords, Arc::from(cells.clone_box())));
+        index_entries.push((key.coords, entity));
+    }
+
+    snapshots.rebuild(snapshot_entries.into_iter());
+    index.rebuild(index_entries.into_iter());
+}
+
+fn step_chunks(
+    mut clock: ResMut<SimulationClock>,
+    mut speed: ResMut<SimulationSpeed>,
+    mut budget: ResMut<SimulationBudget>,
+    snapshots: Res<ChunkSnapshots>,
+    rule: Res<AutomataRule>,
+    query: Query<(Entity, &ChunkKey)>,
+    cells_query: Query<&ChunkCells>,
+    mut next_query: Query<&mut ChunkCellsNext>,
+) {
+    if clock.steps_requested == 0 {
+        return;
+    }
+
+    let start = Instant::now();
+    let mut results = Vec::with_capacity(query.iter().len());
+
+    for (entity, key) in query.iter() {
+        if let Some(snapshot) = snapshots.get(key.coords) {
+            let mut buffer = vec![AutomataState::default(); CHUNK_VOLUME];
+            step_chunk(snapshot, key.coords, &snapshots, &rule, &mut buffer);
+            results.push((entity, buffer));
+        } else if let Ok(cells) = cells_query.get(entity) {
+            // No snapshot available (chunk added mid-frame); fall back to current cells.
+            let mut buffer = vec![AutomataState::default(); CHUNK_VOLUME];
+            step_chunk(cells.as_slice(), key.coords, &snapshots, &rule, &mut buffer);
+            results.push((entity, buffer));
+        }
+    }
+
+    for (entity, buffer) in results {
+        if let Ok(mut next) = next_query.get_mut(entity) {
+            next.as_mut_slice().copy_from_slice(&buffer);
+        }
+    }
+
+    let elapsed_ms = start.elapsed().as_secs_f32() * 1000.0;
+    budget.record_step(elapsed_ms);
+    speed.apply_budget_feedback(&budget);
+    clock.steps_requested = 0;
+    clock.executed_step = true;
+}
+
+fn apply_next_cells(
+    mut clock: ResMut<SimulationClock>,
+    mut query: Query<(&mut ChunkCells, &ChunkCellsNext)>,
+) {
+    if !clock.executed_step {
+        return;
+    }
+
+    for (mut cells, next) in query.iter_mut() {
+        cells.write_from_slice(next.as_slice());
+    }
+
+    clock.executed_step = false;
+}
+
+fn step_chunk(
+    current_chunk: &[AutomataState],
+    coords: IVec3,
+    snapshots: &ChunkSnapshots,
+    rule: &AutomataRule,
+    output: &mut [AutomataState],
+) {
+    for x in 0..CHUNK_EDGE {
+        for y in 0..CHUNK_EDGE {
+            for z in 0..CHUNK_EDGE {
+                let local = IVec3::new(x, y, z);
+                let idx = linear_index(local);
+                let neighbors = count_active_neighbors(snapshots, coords, local);
+                let current = current_chunk[idx];
+                output[idx] = rule.next_state(current, neighbors);
+            }
+        }
+    }
+}
+
+fn count_active_neighbors(snapshots: &ChunkSnapshots, chunk_coords: IVec3, local: IVec3) -> u8 {
+    let mut count = 0u8;
+
+    for dx in -1..=1 {
+        for dy in -1..=1 {
+            for dz in -1..=1 {
+                if dx == 0 && dy == 0 && dz == 0 {
+                    continue;
+                }
+
+                let offset = IVec3::new(dx, dy, dz);
+                if let Some(value) = sample_cell(snapshots, chunk_coords, local + offset) {
+                    if value.is_alive() {
+                        count = count.saturating_add(1);
+                    }
+                }
+            }
+        }
+    }
+
+    count
+}
+
+fn sample_cell(
+    snapshots: &ChunkSnapshots,
+    mut chunk_coords: IVec3,
+    mut local: IVec3,
+) -> Option<AutomataState> {
+    let edge = CHUNK_EDGE;
+
+    if local.x < 0 {
+        chunk_coords.x -= 1;
+        local.x += edge;
+    } else if local.x >= edge {
+        chunk_coords.x += 1;
+        local.x -= edge;
+    }
+
+    if local.y < 0 {
+        chunk_coords.y -= 1;
+        local.y += edge;
+    } else if local.y >= edge {
+        chunk_coords.y += 1;
+        local.y -= edge;
+    }
+
+    if local.z < 0 {
+        chunk_coords.z -= 1;
+        local.z += edge;
+    } else if local.z >= edge {
+        chunk_coords.z += 1;
+        local.z -= edge;
+    }
+
+    if let Some(chunk) = snapshots.get(chunk_coords) {
+        let index = linear_index(local);
+        Some(chunk[index])
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn linear_index(local: IVec3) -> usize {
+    let edge = CHUNK_EDGE as usize;
+    (local.x as usize * edge * edge) + (local.y as usize * edge) + local.z as usize
+}
+
+#[inline]
+fn morton_encode(coords: IVec3) -> u64 {
+    let x = (coords.x + MORTON_BIAS) as u64;
+    let y = (coords.y + MORTON_BIAS) as u64;
+    let z = (coords.z + MORTON_BIAS) as u64;
+
+    part1by2(x) | (part1by2(y) << 1) | (part1by2(z) << 2)
+}
+
+#[inline]
+fn part1by2(mut n: u64) -> u64 {
+    n &= 0x1f_ffff;
+    n = (n | (n << 32)) & 0x1f00_0000_00ff_ff;
+    n = (n | (n << 16)) & 0x1f00_00ff_0000_ff;
+    n = (n | (n << 8)) & 0x100f_00f0_0f00_f00f;
+    n = (n | (n << 4)) & 0x10c3_0c30_c30c_30c3;
+    n = (n | (n << 2)) & 0x1249_2492_4924_9249;
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Flags;
+    use std::collections::HashSet;
+
+    #[test]
+    fn morton_keys_are_unique_for_local_region() {
+        let mut seen = HashSet::new();
+        for x in -2..=2 {
+            for y in -2..=2 {
+                for z in -2..=2 {
+                    let key = morton_encode(IVec3::new(x, y, z));
+                    assert!(seen.insert(key));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn neighbor_lookup_crosses_chunk_boundary() {
+        let mut snapshots = ChunkSnapshots::default();
+        let mut map = HashMap::default();
+
+        let mut center = vec![AutomataState::default(); CHUNK_VOLUME];
+        center[linear_index(IVec3::new(CHUNK_EDGE - 1, CHUNK_EDGE - 1, CHUNK_EDGE - 1))] =
+            AutomataState::from_components(1, Flags::AUTOMATA_FLAG);
+        map.insert(IVec3::ZERO, Arc::from(center.into_boxed_slice()));
+
+        let mut neighbor = vec![AutomataState::default(); CHUNK_VOLUME];
+        neighbor[linear_index(IVec3::new(0, 0, 0))] =
+            AutomataState::from_components(1, Flags::AUTOMATA_FLAG);
+        map.insert(IVec3::new(1, 1, 1), Arc::from(neighbor.into_boxed_slice()));
+
+        snapshots.map = map;
+
+        let count = count_active_neighbors(
+            &snapshots,
+            IVec3::ZERO,
+            IVec3::new(CHUNK_EDGE - 1, CHUNK_EDGE - 1, CHUNK_EDGE - 1),
+        );
+        assert_eq!(count, 1);
+    }
+}

--- a/src/voxel_pipeline/compute/animation.rs
+++ b/src/voxel_pipeline/compute/animation.rs
@@ -21,8 +21,9 @@ impl FromWorld for Pipeline {
         let compute_bind_group_layout = world.resource::<ComputeData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/animation.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/animation.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("animation pipeline")),

--- a/src/voxel_pipeline/compute/automata.rs
+++ b/src/voxel_pipeline/compute/automata.rs
@@ -24,8 +24,9 @@ impl FromWorld for Pipeline {
         let compute_bind_group_layout = world.resource::<ComputeData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/automata.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/automata.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("automata pipeline")),

--- a/src/voxel_pipeline/compute/clear.rs
+++ b/src/voxel_pipeline/compute/clear.rs
@@ -22,8 +22,9 @@ impl FromWorld for Pipeline {
         let voxel_bind_group_layout = world.resource::<VoxelData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/clear.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/clear.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("clear pipeline")),

--- a/src/voxel_pipeline/compute/physics.rs
+++ b/src/voxel_pipeline/compute/physics.rs
@@ -21,8 +21,9 @@ impl FromWorld for Pipeline {
         let compute_bind_group_layout = world.resource::<ComputeData>().bind_group_layout.clone();
 
         let asset_server = world.resource::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/physics.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/physics.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("physics pipeline")),

--- a/src/voxel_pipeline/compute/rebuild.rs
+++ b/src/voxel_pipeline/compute/rebuild.rs
@@ -23,8 +23,9 @@ impl FromWorld for Pipeline {
         let voxel_bind_group_layout = world.resource::<VoxelData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/rebuild.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/rebuild.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("rebuild pipeline")),

--- a/src/voxel_pipeline/voxelization.rs
+++ b/src/voxel_pipeline/voxelization.rs
@@ -286,7 +286,7 @@ impl SpecializedMeshPipeline for VoxelizationPipeline {
         descriptor.vertex.shader = VOXELIZATION_SHADER_HANDLE;
         descriptor.fragment.as_mut().unwrap().shader = VOXELIZATION_SHADER_HANDLE;
 
-        // 
+        //
         descriptor
             .vertex
             .shader_defs


### PR DESCRIPTION
## Summary
- replace the automata state alias with a packed struct that mirrors Bevy's R16Uint voxel layout and exposes helpers for material/flag access
- update the cellular automata rule logic, neighbor counting, and chunk buffers to respect Bevy flag semantics and provide packed conversion utilities
- document how to round-trip chunk data between CPU and GPU in the Stage 0 roadmap

## Testing
- cargo check
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68d8ba17b8fc8328af2b3002fe5a4302