### PR TITLE
Implement fixed-step CA runtime and planetary roadmap

### DIFF
--- a/ROADMAP_MVP.md
+++ b/ROADMAP_MVP.md
@@ -1,0 +1,84 @@
+# Planetary Cellular Automata Roadmap (Room → Planet)
+
+This roadmap outlines the concrete engine work needed to evolve the current Bevy voxel prototype into a destructible planet-scale cellular automaton. Every stage includes the exact glue code or crate integrations that hook into the codebase under `src/simulation.rs`, `src/lib.rs`, and `src/voxel_pipeline` so the plan can be implemented without placeholders.
+
+## Stage 0 — Room-Scale Prototype
+1. **Data Model**
+   - Keep chunk state in the `ChunkCells`/`ChunkCellsNext` components defined in `src/simulation.rs`. Each chunk owns a `Box<[AutomataState]>` sized to `CHUNK_VOLUME` (32³). `AutomataState` mirrors the renderer’s `R16Uint` layout, so you can copy GPU buffers directly via `ChunkCells::write_from_packed` and `ChunkCells::to_packed_vec` without repacking material/flag bytes.
+   - Instantiate chunks with the provided `ChunkBundle::new(coords)` constructor so entities always carry `ChunkKey`, `ChunkCells`, and `ChunkCellsNext` together. Use `ChunkBundle::from_generator` when seeding test rooms procedurally.
+   - Register the `CellularAutomataPlugin` from `src/lib.rs` to bring in the fixed-step scheduler (`SimulationSet`) and runtime resources (`SimulationSpeed`, `SimulationBudget`, `SimulationClock`, `ChunkSnapshots`, and `ChunkIndex`).
+2. **Simulation Loop**
+   - Systems already exist in `src/simulation.rs`: `tick_simulation` accumulates delta time, `snapshot_chunks` copies read-only state into `ChunkSnapshots`, `step_chunks` iterates up to `MAX_STEPS_PER_FRAME` steps, and `apply_next_cells` swaps buffers. Wire them ahead of rendering by adding the plugin, or schedule custom rules in the `SimulationSet::Step` set:
+     ```rust
+     app.add_plugins(CellularAutomataPlugin)
+         .add_systems(Update, custom_room_rule.in_set(SimulationSet::Step));
+
+     fn custom_room_rule(
+         rule: Res<AutomataRule>,
+         mut next_chunks: Query<&mut ChunkCellsNext>,
+     ) {
+         for mut buffer in &mut next_chunks {
+             // mutate `buffer.as_mut_slice()` here before `apply_next_cells` runs
+         }
+     }
+     ```
+   - Adjust playback speed at runtime through `SimulationSpeed` (e.g., `commands.insert_resource(SimulationSpeed { factor: 2.0, ..default() })`). The budget controller automatically clamps the factor based on the moving average recorded in `SimulationBudget`.
+3. **Rendering / GPU Interop**
+   - When CPU rules change voxels, push the data into the renderer by calling `ChunkCells::to_packed_vec()` and uploading to the existing compute pipelines under `src/voxel_pipeline/compute`. Use the shader handles registered in `voxel_pipeline::compute::add_compute_pipelines` to trigger rebuilds.
+   - For room-scale debugging, reuse `VoxelizationBundle` and `VoxelCameraBundle` from `src/lib.rs` to spawn visualizers that track the CA output.
+4. **Testing**
+   - The regression tests in `src/simulation.rs::tests` (Morton uniqueness, cross-chunk neighbor lookup, accumulator draining) document the base invariants. Extend them with scenario-specific checks and run with `cargo test --lib` to guarantee determinism.
+
+## Stage 1 — Building / City Scale (~1 km)
+1. **Chunk Paging**
+   - Back CA chunks with a `HashMap<IVec3, ChunkBundle>` or `slotmap::SlotMap` keyed by the `ChunkKey.coords`. When evicting chunks, serialize `ChunkCells::to_packed_vec()` and store the metadata `(coords, SimulationClock::accumulator, tick)` so reloading resumes deterministically.
+   - Drive background streaming via `ComputeTaskPool::scope` (already imported in `src/simulation.rs`) to hydrate chunks without blocking the main thread.
+2. **Gravity Core**
+   - Introduce a `PlanetCenter: DVec3` resource and apply gravity within physics or particle systems: `let gravity = (planet_center - world_pos).normalize() * g;`. `VoxelPhysics` components in `src/lib.rs` already carry `gravity` fields—update them when moving chunks.
+3. **Performance Controls**
+   - Monitor the moving average from `SimulationBudget::rolling_ms`. If it exceeds `target_ms`, either lower `SimulationSpeed.factor` or update subsets of chunks by filtering on `ChunkKey.morton % n` for shell-based throttling.
+4. **Visualization**
+   - Group render uploads per material by reading `AutomataState::material()` while meshing to keep draw calls low. The compute pipelines under `src/voxel_pipeline/compute/*.rs` already batch WGSL shader uploads; extend them with material sorting before dispatch.
+5. **Persistence**
+   - Save chunks when removed from `ChunkIndex` and reload through `ChunkCells::write_from_packed`. Keep snapshots consistent by reinserting entries into `ChunkSnapshots` before the next `step_chunks` iteration.
+
+## Stage 2 — Regional Scale (~100 km)
+1. **Adopt `big_space` Coordinates**
+   - Add `big_space = { version = "0.10", features = ["bevy"] }` to `Cargo.toml`, register `BigSpacePlugin`, and attach a `FloatingOrigin` camera (see `docs/big_space_research.md`). Store each chunk’s `GridCell` alongside its `ChunkKey` so CA systems can map between integer grid cells and local voxel indices with millimeter precision.
+2. **Spatial Hashing**
+   - Replace the plain `HashMap` inside `ChunkIndex` with `big_space::GridHashMap` to fetch neighboring chunks in O(1). When calling `count_active_neighbors`, translate offsets using `GridCell::neighbor(offset)` before querying `ChunkSnapshots`.
+3. **Morton Ordering with `ilattice`**
+   - Pull in `ilattice = { version = "0.4", features = ["glam"] }` and replace `morton_encode`/`part1by2` with `MortonEncoder3D::encode` for clarity. Cache `MortonKey(u64)` components and use them to sort streaming requests or GPU upload queues.
+4. **Level of Detail**
+   - Generate downsampled macro cells (8³ or 16³) on worker threads and render them via instancing while detailed chunks load. Record the macro state in secondary textures so compute shaders can blend transitions.
+5. **Time Dilation**
+   - Advance latitudinal bands on alternating frames by checking `ChunkKey.coords.y % 2`. Combine with `SimulationSpeed` to keep the global clock smooth while letting distant regions update less frequently.
+
+## Stage 3 — Planetary Scale (~6,000 km radius)
+1. **Hierarchical Storage**
+   - Layer an `oktree::Octree` over the chunk pager (see `docs/oktree_research.md`). Keep dense mantle data in compressed bricks (RLE or sparse sets) and hydrate them into active `ChunkCells` when the player or fracture front approaches. Map octree leaves to chunk morton keys to keep streaming cache-friendly.
+2. **Gravity & Physics**
+   - Use `big_space::BigSpace` to query absolute positions: `let offset = big_space.absolute_position(entity);`. Feed that into physics integration (`VoxelPhysics::gravity`) using double precision before projecting back to local chunk coordinates.
+3. **Planet Slicing**
+   - Cast rays through the octree to find intersected chunks, then enqueue compute shader cuts. Upload plane equations or boolean volumes to the compute pipelines (see `src/voxel_pipeline/compute/rebuild.rs`) and write results back with `ChunkCells::write_from_packed`.
+4. **Streaming & Networking**
+   - Predict camera motion from velocity + gravity, prefetch upcoming `GridCell`s, and stream chunk diffs over the network. Persist `(GridCell, AutomataState)` deltas so server and client remain deterministic.
+5. **Visualization**
+   - Integrate atmospheric scattering and horizon culling; feed aggregated CA metrics into spherical harmonics for the planet’s far side while detailed chunks remain local.
+
+## Stage 4 — Planetary Optimization Loop
+1. **Performance Budgeting**
+   - Maintain a 16 ms frame budget: 6 ms CA, 4 ms meshing, 4 ms rendering, 2 ms margin. If CA overruns, dial back `SimulationSpeed.factor` or enlarge `CHUNK_EDGE` temporarily for low-activity regions.
+2. **GPU Memory Forecast (16 GB)**
+   - Reserve ~4 GB for render targets and 1 GB for uniform/storage buffers, leaving 11 GB for meshes. At ~1 MB per chunk mesh you can keep ≈11 000 active chunks. Stream additional chunks through compressed brick caches.
+3. **Tooling**
+   - Build profiling overlays showing chunk timings, background task latency, and floating-origin recenter counts. Log `SimulationBudget::rolling_ms` and chunk step durations to quickly spot regressions.
+4. **Library Vetting**
+   - Use `ilattice` for Morton math and stay off `building-blocks` in the MVP (documented in `docs/building_blocks_research.md`). Port required clipmap/compression ideas directly into Bevy ECS systems for long-term maintainability.
+
+## Stage 5 — Shipping Checklist
+- Validate deterministic replay across saves by capturing `SimulationClock` state and all chunk diffs.
+- Stress-test real-time slicing against the octree-backed mesher; ensure `SimulationSpeed` gracefully slows instead of stalling.
+- Document tuning knobs (chunk size, LOD radius, simulation budget, streaming thresholds) so the engine can be configured for a range of GPUs.
+
+By following these stages the engine scales from a room-sized automaton to a planetary simulation while preserving determinism, GPU/CPU interoperability, and realistic gravity oriented toward the planet core.

--- a/docs/big_space_research.md
+++ b/docs/big_space_research.md
@@ -1,0 +1,42 @@
+# `big_space` Coordinate System Research
+
+## Highlights
+- Big Space advertises "huge worlds, high performance, no dependencies" and reuses `Transform`/`GlobalTransform` so existing Bevy systems continue to function ([README](https://github.com/aevyrie/big_space)).
+- Supports precision from proton to observable-universe scale by chaining integer grids (`i8` up to `i128`) and floating origins ([README highlights](https://github.com/aevyrie/big_space/blob/main/README.md#highlights)).
+- Provides spatial hashing (`GridHashMap`) and partitioning helpers to accelerate neighbor lookup for large entity sets ([docs.rs Quick Reference](https://docs.rs/big_space/latest/big_space/)).
+
+## Core Concepts
+- **BigSpace**: root component that anchors a high-precision hierarchy and holds grid parameters for descendants.
+- **FloatingOrigin**: entity whose transform defines the local render origin, minimizing floating point error for 32-bit GPU transforms ([docs.rs Floating Origin](https://docs.rs/big_space/latest/big_space/#floating-origin)).
+- **Grid / GridCell**: define integer cell size and indices for nested grids, letting you partition the world into coarse-to-fine spatial buckets without coordinate drift ([docs.rs Integer Grid](https://docs.rs/big_space/latest/big_space/#integer-grid)).
+
+## Integration Sketch
+```rust
+use big_space::prelude::*;
+use bevy::prelude::*;
+
+fn setup(mut commands: Commands) {
+    commands.spawn((BigSpace::default(), SpatialBundle::default()));
+    commands.spawn((
+        FloatingOrigin,
+        Camera3dBundle::default(),
+        Grid::new(GridPrecision::Int64, 1024.0),
+    ));
+    commands.spawn((
+        GridCell::new(IVec3::ZERO),
+        Transform::from_translation(Vec3::new(0.0, 0.0, 0.0)),
+        GlobalTransform::default(),
+    ));
+}
+```
+The plugin rewrites `Transform` propagation so entities stay centered around the origin while preserving absolute `GridCell` indices for simulation logic.
+
+## Benefits for Planetary CA
+- Integer grids let you address voxels across planetary scales without precision loss; CA updates can operate on `(grid_cell, local_pos)` pairs, while rendering works in f32 space relative to the floating origin.
+- Spatial hash (`GridHash`) allows rapid neighbor queries across chunk boundaries, useful for diffusing CA states and synchronizing fracture fronts.
+- Compatible with `oktree` or chunked voxel storage: treat each chunk as a `GridCell` child and maintain absolute indexing for streaming.
+
+## Considerations
+- You must manage recentering frequency: `FloatingOrigin` systems recenter when the tracked entity leaves a cell; ensure CA job scheduling tolerates the momentary `Transform` update.
+- Physics/gravity require custom integration with Big Space coordinates; align gravitational acceleration toward the planetary center expressed in high-precision grid space, then convert to local `Transform` for rendering.
+- Network replication or save files should serialize `GridCell` + local transform rather than raw floats to avoid drift.

--- a/docs/building_blocks_research.md
+++ b/docs/building_blocks_research.md
@@ -1,0 +1,36 @@
+# Building Blocks Crate Assessment
+
+## Overview
+- **Repository**: https://github.com/bonsairobo/building-blocks
+- **Status**: Maintenance mode; author recommends migrating to smaller successor crates focused on slice-based APIs backed by the feldspar project.
+- **Scope**: Provides voxel-focused data structures, LOD clipmaps, chunk storage, procedural sampling helpers, greedy and Surface Nets meshing, chunk databases with compression, and spatial queries.
+
+## Strengths
+- Ready-made chunk trees with split/merge events for clipmap-driven LOD and streaming.
+- Multiple meshing algorithms (greedy, Surface Nets) usable on CPU workers with configurable voxel sizes.
+- `ChunkDb` abstraction for compressed persistence with `sled`, supporting LZ4/Snappy backends and configurable features.
+- Rich documentation and examples covering sampling SDFs, chunk paging, and clipmap management.
+
+## Weaknesses / Risks
+- Maintenance hiatus makes long-term support uncertain; upstream recommends new crates in the author's "my-stack" list instead.
+- API centered around bespoke `Array`/`Extent` types may conflict with existing ECS-centric storage, leading to conversion overhead.
+- Heavy dependency surface (meshing, compression, pathfinding) when enabling default features; requires careful feature gating for WASM or minimal builds.
+
+## Applicability to Planetary CA MVP
+- **Chunk storage & paging**: `ChunkTree` could prototype clipmap paging before custom solution, but lack of maintenance makes it risky for core MVP. Favor integrating concepts rather than depending on crate binaries.
+- **Meshing**: Greedy meshing implementation can serve as reference for GPU/compute rewrite, but shipping dependency into MVP is optional.
+- **Compression**: `ChunkDb` demonstrates chunk diff persistence; evaluate porting design to in-house storage or using smaller crates that remain maintained.
+
+## Integration Notes
+- If prototyping with the crate, disable default features and enable only required modules to limit dependencies:
+  ```toml
+  [dependencies]
+  building-blocks = { version = "0.7", default-features = false, features = [
+      "array", "chunk_map", "chunk_tree", "lod", "mesh"
+  ] }
+  ```
+- Convert between `building_blocks::core::Point3i` and Bevy `IVec3` through `.into()` when the "glam" feature is enabled.
+- Run meshing on worker threads and upload results to Bevy using `RenderAsset` implementations to keep render graph decoupled from CPU mesher.
+
+## Recommendation
+Treat Building Blocks as a design reference and optional prototype helper. For the MVP planetary CA, replicate core ideas (clipmaps, chunk compression) with maintained, ECS-friendly libraries or in-house implementations to avoid lock-in to an unmaintained dependency.

--- a/docs/ilattice_research.md
+++ b/docs/ilattice_research.md
@@ -1,0 +1,42 @@
+# ilattice Crate Assessment
+
+## Overview
+- **Repository**: https://github.com/bonsairobo/ilattice-rs
+- **Purpose**: Generic math utilities for integer lattices (regular 2D/3D grids) with tight integration with `glam` vector types.
+- **Core Features**:
+  - Trait-based abstractions for integer and real vector math (`IntegerVector`, extent utilities, morton encoding).
+  - Re-exported `glam` types for convenience, providing `IVec2/3`, `UVec2/3`, and `Vec2/3` implementations.
+  - Helpers for Morton (Z-curve) indexing to linearize 3D grids for cache-friendly storage.
+
+## Strengths
+- Minimal dependency footprint and actively published (0.4.0) with focused scope.
+- Drop-in conversions for `glam` types simplify interoperability with Bevy transforms and chunk coordinates.
+- Provides generic traits usable in custom data structures, enabling compile-time dimension configuration and SIMD-friendly math.
+
+## Weaknesses / Risks
+- Does not include storage or meshing primitives; only math helpers. Needs pairing with custom chunk storage.
+- Limited documentation on integration patterns beyond lattice math; requires in-house design for chunk streaming.
+
+## Applicability to Planetary CA MVP
+- Useful for Morton indexing of chunk IDs and sub-voxel coordinates when building cache-friendly structures or GPU-friendly buffers.
+- Can underpin custom clipmap/octree indexing without adopting large frameworks.
+- Lightweight enough to include directly in MVP for coordinate math consistency alongside `big_space` high-precision transforms.
+
+## Integration Notes
+- Add dependency:
+  ```toml
+  [dependencies]
+  ilattice = { version = "0.4", features = ["glam"] }
+  ```
+- Use Morton utilities for chunk atlas packing:
+  ```rust
+  use ilattice::morton::{MortonEncoder3D, morton_decode3d};
+
+  let encoder = MortonEncoder3D::default();
+  let morton_index = encoder.encode(IVec3::new(x, y, z));
+  let coords = morton_decode3d(morton_index);
+  ```
+- Combine with `big_space` grid cells by storing `MortonKey` within chunk components for deterministic ordering during streaming.
+
+## Recommendation
+Adopt `ilattice` in the MVP to standardize integer lattice math, Morton ordering, and conversions with `glam`. Its focused feature set complements custom chunk storage without imposing heavy architecture constraints.

--- a/docs/oktree_research.md
+++ b/docs/oktree_research.md
@@ -1,0 +1,39 @@
+# Oaktree (`oktree`) Research
+
+## Crate Overview
+- **Crate**: [`oktree`](https://crates.io/crates/oktree) v0.4.1
+- **Purpose**: High-performance, pointer-free sparse voxel octree with optional Bevy integration feature flag.
+- **Key design points**:
+  - Avoids smart pointers to maximize cache locality and performance, instead using contiguous buffers and indices for nodes ([docs.rs reference](https://docs.rs/oktree/0.4.1/oktree/)).
+  - Provides Bevy feature flag (`features = ["bevy"]`) to expose intersection methods and component wrappers for engine integration ([docs.rs feature list](https://docs.rs/oktree/0.4.1/oktree/#features)).
+
+## Benchmark Summary
+The published benchmark for `oktree` uses a `4096³` volume and shows the following timings on release builds (`cargo bench --all-features`) [source](https://docs.rs/oktree/0.4.1/oktree/#benchmark):
+
+| Operation | Quantity | Time |
+|-----------|----------|------|
+| Insertion | 65,536 cells | 21 ms |
+| Removal | 65,536 cells | 1.5 ms |
+| Point lookup | 65,536 searches | 12 ms |
+| Ray intersection | 4,096 rays vs 65,536 cells | 37 ms |
+| Sphere intersection | 4,096 spheres vs 65,536 cells | 8 ms |
+| Box intersection | 4,096 boxes vs 65,536 cells | 7 ms |
+
+These numbers imply ~3.1M insertions per second and ~2.8M ray tests per second on the reference hardware. For CA workloads the branch factor (8) suits sparse activation patterns (e.g., cellular surfaces or shells) rather than densely active solids.
+
+## Integration Notes
+- Initial tree construction uses `Octree::from_aabb_with_capacity(aabb, capacity)` where capacity is the maximum leaf load before subdivision; tune to control tree depth vs. branching overhead ([docs.rs usage](https://docs.rs/oktree/0.4.1/oktree/#example)).
+- Ray/sphere/box intersection helpers depend on the Bevy feature flag; enabling it adds `bevy` crate as a dependency and exports bundles for rendering debug draws.
+- The crate exposes `Octree::iter()` and neighborhood traversal utilities to stream active cells into GPU-friendly buffers for chunk meshing.
+
+## Suitability for Planetary CA
+- Works best for sparse volumes (e.g., thin atmosphere layers or crust shells). Dense planetary interiors will cause high branching depth and degrade cache performance. Combining octrees with chunked voxel bricks (e.g., `32³` dense tiles) reduces pointer chasing by limiting tree depth.
+- Node capacity is stored as `Unsigned` generics (`u8`..`u128`), enabling very deep hierarchies for huge worlds, but memory usage grows exponentially if the planet interior is densely populated.
+- In scenarios with frequent large-scale edits (splitting planet), consider hybrid approach: maintain coarse-grained `oktree` for active fracture front and offload interior to chunked arrays; leverage `oktree` for collision/visibility queries.
+
+## Alternative Structures
+- **Sparse grids with paging** (e.g., hash-map keyed chunks) offer predictable memory/performance for dense fill factors and are easier to stream to GPU.
+- **Voxel DAGs / Sparse Voxel Octrees (SVO)** are heavier to update but compress static regions better—useful for far-field read-only LOD once the CA stabilizes.
+- **Dual contouring on chunked terrain** is friendlier to incremental meshing than per-voxel ray queries; combine with compute shaders for fracture updates when splitting the planet.
+
+In summary, `oktree` is suitable for sparse, high-frequency query workloads (collisions, neighbor search) but should be combined with chunked dense storage for planetary cellular automata.

--- a/docs/scaling_strategies.md
+++ b/docs/scaling_strategies.md
@@ -1,0 +1,36 @@
+# Scaling Strategies for Planetary Cellular Automata
+
+## Engine-Level Optimizations
+- **Profile configs**: Enable dependency optimizations even in dev builds to keep Bevy responsive without losing debug assertions ([Bevy Cheatbook - Performance](https://bevy-cheatbook.github.io/pitfalls/performance.html)). Suggested `Cargo.toml` snippet:
+  ```toml
+  [profile.dev]
+  opt-level = 1
+  [profile.dev.package."*"]
+  opt-level = 3
+  ```
+- **Task scheduling**: Offload CA updates to `bevy_tasks::ComputeTaskPool` or dedicated `TaskPoolBuilder` instances; the task API supports scoped parallel iteration and work stealing ([bevy_tasks README](https://github.com/bevyengine/bevy/tree/main/crates/bevy_tasks)).
+- **System ordering**: Use `bevy::ecs::schedule::Schedule` with custom sets (e.g., `UpdateSet::Simulation`) so CA updates run before rendering recenter events from `big_space`.
+
+## Spatial Partitioning
+- Combine chunked voxel bricks (e.g., `32³` or `64³`) with higher-level spatial structures:
+  - `GridHashMap` from `big_space` for O(1) neighbor discovery across chunk boundaries.
+  - Optional `oktree` overlays for sparsely active regions (e.g., atmosphere, weather) to reduce memory footprint.
+- Maintain multi-resolution LOD chain: near-field uses dense simulation, mid-field uses aggregated chunk states (averaged or downsampled), far-field uses analytical/texture-driven approximations.
+
+## Time Dilation & Simulation Budgeting
+- Track average CA step cost (ms) and dynamically scale simulation rate when exceeding frame budget. Provide `SimulationSpeed` resource that lerps toward target `dt` to avoid abrupt slowdowns.
+- Permit "batch" updates by splitting the planet into rings or face patches updated on alternating frames; ensures consistent progress without blocking render thread.
+
+## Rendering Considerations
+- Use instanced meshes or compute-driven mesh generation for active voxels instead of individual entities; mesh generation should operate per chunk.
+- Implement view-dependent LOD: skip CA meshing for chunks outside a camera-dependent radius, fallback to impostor textures or GPU-generated spheres.
+- Employ async GPU uploads (via `RenderAssetUsages::REQUIRES_ASSET_LOADING`) to stream chunk meshes without stalling the main thread.
+
+## Persistence & Streaming
+- Serialize CA state per chunk using `GridCell` indices plus local dense arrays for compatibility with `big_space` coordinates.
+- Implement background streaming threads that prefetch neighbor chunks based on camera velocity and gravity vector, warming caches before the player arrives.
+
+## Failure Modes & Mitigations
+- **Floating origin jitter**: recenter events can cause physics jitter; double-buffer CA-to-physics transforms and apply smoothing.
+- **GPU memory blow-up**: For a 16 GB GPU, reserve <12 GB for chunk meshes/textures to leave headroom for swapchain; this equates to ~12k active chunks at 1 MB each. Use compression or procedural regeneration for far-field data.
+- **Workload spikes when splitting planets**: precompute fracture planes and reuse mesh topology where possible; stream cut geometry via compute shaders to keep CPU cost bounded.

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,11 @@ use bevy::{
 };
 use physics::PhysicsPlugin;
 pub use physics::VOXELS_PER_METER;
+pub use simulation::{
+    AutomataRule, AutomataState, CellularAutomataPlugin, ChunkBundle, ChunkCells, ChunkCellsNext,
+    ChunkIndex, ChunkKey, SimulationBudget, SimulationClock, SimulationSet, SimulationSpeed,
+    CHUNK_EDGE, CHUNK_VOLUME, FIXED_STEP_SECONDS,
+};
 use voxel_pipeline::RenderPlugin;
 pub use voxel_pipeline::{
     trace::TraceSettings, voxelization::VoxelizationMaterial,
@@ -12,6 +17,7 @@ pub use voxel_pipeline::{
 
 mod load;
 mod physics;
+mod simulation;
 mod voxel_pipeline;
 
 #[derive(Component)]
@@ -156,6 +162,7 @@ impl Plugin for BevyVoxelEnginePlugin {
     fn build(&self, app: &mut App) {
         app.insert_resource(Msaa::Off)
             .add_plugins(PhysicsPlugin)
+            .add_plugins(CellularAutomataPlugin)
             .add_plugins(RenderPlugin);
     }
 }

--- a/src/simulation.rs
+++ b/src/simulation.rs
@@ -1,0 +1,801 @@
+use crate::Flags;
+use bevy::{
+    ecs::schedule::SystemSet,
+    prelude::*,
+    utils::{HashMap, Instant},
+};
+use std::sync::Arc;
+
+/// Edge length of a simulation chunk in voxels.
+pub const CHUNK_EDGE: i32 = 32;
+/// Number of voxels contained inside a chunk.
+pub const CHUNK_VOLUME: usize =
+    (CHUNK_EDGE as usize) * (CHUNK_EDGE as usize) * (CHUNK_EDGE as usize);
+/// Fixed time step used to advance the cellular automata.
+pub const FIXED_STEP_SECONDS: f32 = 1.0 / 60.0;
+/// Bias applied to chunk coordinates before Morton encoding.
+const MORTON_BIAS: i32 = 1 << 20;
+/// Maximum number of fixed steps processed per frame to avoid spiraling.
+const MAX_STEPS_PER_FRAME: u32 = 8;
+
+/// Packed material/flag state stored per voxel.
+#[repr(transparent)]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq, Hash)]
+pub struct AutomataState {
+    encoded: u16,
+}
+
+impl AutomataState {
+    /// Constructs a state from palette material and flag byte.
+    pub const fn from_components(material: u8, flags: u8) -> Self {
+        Self {
+            encoded: ((flags as u16) << 8) | material as u16,
+        }
+    }
+
+    /// Constructs a state from the packed 16-bit value stored in GPU textures.
+    pub const fn from_packed(encoded: u16) -> Self {
+        Self { encoded }
+    }
+
+    /// Returns the packed 16-bit representation of the voxel.
+    pub const fn to_packed(self) -> u16 {
+        self.encoded
+    }
+
+    /// Returns the palette material index stored in the low byte.
+    pub const fn material(self) -> u8 {
+        (self.encoded & 0x00FF) as u8
+    }
+
+    /// Returns the voxel flags stored in the high byte.
+    pub const fn flags(self) -> u8 {
+        (self.encoded >> 8) as u8
+    }
+
+    /// Returns true when the voxel stores no material or flags.
+    pub const fn is_empty(self) -> bool {
+        self.encoded == 0
+    }
+
+    /// Returns true when the voxel contains any material.
+    pub const fn is_solid(self) -> bool {
+        self.material() != 0
+    }
+
+    /// Returns true when the voxel participates in the automata rule set.
+    pub const fn is_alive(self) -> bool {
+        (self.flags() & Flags::AUTOMATA_FLAG) != 0 && self.is_solid()
+    }
+
+    /// Returns true when the voxel should be treated as immutable geometry.
+    pub const fn is_static(self) -> bool {
+        self.is_solid() && !self.is_alive()
+    }
+
+    /// Replaces the palette material and returns the new state.
+    pub const fn with_material(self, material: u8) -> Self {
+        Self::from_components(material, self.flags())
+    }
+
+    /// Replaces the flag byte and returns the new state.
+    pub const fn with_flags(self, flags: u8) -> Self {
+        Self::from_components(self.material(), flags)
+    }
+
+    /// Returns the (material, flags) tuple for interoperability helpers.
+    pub const fn to_components(self) -> (u8, u8) {
+        (self.material(), self.flags())
+    }
+}
+
+impl From<u16> for AutomataState {
+    fn from(value: u16) -> Self {
+        Self::from_packed(value)
+    }
+}
+
+impl From<AutomataState> for u16 {
+    fn from(value: AutomataState) -> Self {
+        value.to_packed()
+    }
+}
+
+impl From<(u8, u8)> for AutomataState {
+    fn from((material, flags): (u8, u8)) -> Self {
+        Self::from_components(material, flags)
+    }
+}
+
+/// Resource controlling the simulation playback speed.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SimulationSpeed {
+    /// Multiplier applied to the fixed simulation step.
+    pub factor: f32,
+    /// Lower clamp to keep the simulation responsive under load.
+    pub min_factor: f32,
+    /// Upper clamp to avoid runaway acceleration.
+    pub max_factor: f32,
+}
+
+impl Default for SimulationSpeed {
+    fn default() -> Self {
+        Self {
+            factor: 1.0,
+            min_factor: 0.1,
+            max_factor: 4.0,
+        }
+    }
+}
+
+impl SimulationSpeed {
+    fn apply_budget_feedback(&mut self, budget: &SimulationBudget) {
+        if budget.rolling_ms > budget.target_ms {
+            self.factor = (self.factor * 0.9).max(self.min_factor);
+        } else if budget.rolling_ms < budget.target_ms * 0.5 {
+            self.factor = (self.factor * 1.05).min(self.max_factor);
+        }
+    }
+}
+
+/// Tracks how much CPU time the simulation consumed and adjusts playback speed targets.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SimulationBudget {
+    /// Maximum milliseconds budgeted per fixed-step update.
+    pub target_ms: f32,
+    smoothing: f32,
+    /// Exponential moving average of recent step times.
+    pub rolling_ms: f32,
+}
+
+impl Default for SimulationBudget {
+    fn default() -> Self {
+        Self {
+            target_ms: 6.0,
+            smoothing: 0.2,
+            rolling_ms: 0.0,
+        }
+    }
+}
+
+impl SimulationBudget {
+    pub fn record_step(&mut self, elapsed_ms: f32) {
+        if self.rolling_ms == 0.0 {
+            self.rolling_ms = elapsed_ms;
+        } else {
+            self.rolling_ms += self.smoothing * (elapsed_ms - self.rolling_ms);
+        }
+    }
+}
+
+/// Fixed-step clock so the automata runs deterministically regardless of framerate.
+#[derive(Resource, Debug, Clone, Copy)]
+pub struct SimulationClock {
+    accumulator: f32,
+    /// Number of steps requested during the current frame.
+    pub steps_requested: u32,
+    /// Whether the step for this frame has completed.
+    pub executed_step: bool,
+}
+
+impl Default for SimulationClock {
+    fn default() -> Self {
+        Self {
+            accumulator: 0.0,
+            steps_requested: 0,
+            executed_step: false,
+        }
+    }
+}
+
+/// Birth/survival rule configured for the MVP.
+#[derive(Resource, Debug, Clone)]
+pub struct AutomataRule {
+    pub birth: Vec<u8>,
+    pub survive: Vec<u8>,
+    /// Palette index used when birthing a new automata voxel.
+    pub birth_material: u8,
+    /// Flags applied to newly created automata voxels.
+    pub birth_flags: u8,
+    /// State applied to voxels that fall out of the rule (typically empty space).
+    pub inactive_state: AutomataState,
+}
+
+impl Default for AutomataRule {
+    fn default() -> Self {
+        // Use a 3D Life variant (B5/S45) that produces interesting structures.
+        Self {
+            birth: vec![5],
+            survive: vec![4, 5],
+            birth_material: 1,
+            birth_flags: Flags::AUTOMATA_FLAG,
+            inactive_state: AutomataState::default(),
+        }
+    }
+}
+
+impl AutomataRule {
+    #[inline]
+    fn alive_template(&self) -> AutomataState {
+        AutomataState::from_components(self.birth_material, self.birth_flags | Flags::AUTOMATA_FLAG)
+    }
+
+    #[inline]
+    fn next_state(&self, current: AutomataState, neighbors: u8) -> AutomataState {
+        if current.is_static() {
+            return current;
+        }
+
+        if current.is_alive() {
+            if self.survive.contains(&neighbors) {
+                let mut flags = current.flags() | Flags::AUTOMATA_FLAG;
+                flags |= self.birth_flags & !Flags::AUTOMATA_FLAG;
+                current.with_flags(flags)
+            } else {
+                self.inactive_state
+            }
+        } else if self.birth.contains(&neighbors) {
+            self.alive_template()
+        } else {
+            self.inactive_state
+        }
+    }
+}
+
+/// Component storing the Morton key for a chunk along with its integer coordinates.
+#[derive(Component, Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct ChunkKey {
+    pub coords: IVec3,
+    pub morton: u64,
+}
+
+impl ChunkKey {
+    pub fn new(coords: IVec3) -> Self {
+        Self {
+            morton: morton_encode(coords),
+            coords,
+        }
+    }
+}
+
+/// Component containing the active state for every cell in a chunk.
+#[derive(Component, Clone)]
+pub struct ChunkCells {
+    data: Box<[AutomataState]>,
+}
+
+impl ChunkCells {
+    pub fn filled(value: AutomataState) -> Self {
+        Self {
+            data: vec![value; CHUNK_VOLUME].into_boxed_slice(),
+        }
+    }
+
+    pub fn from_generator<F>(mut generator: F) -> Self
+    where
+        F: FnMut(IVec3) -> AutomataState,
+    {
+        let mut data = Vec::with_capacity(CHUNK_VOLUME);
+        for x in 0..CHUNK_EDGE {
+            for y in 0..CHUNK_EDGE {
+                for z in 0..CHUNK_EDGE {
+                    data.push(generator(IVec3::new(x, y, z)));
+                }
+            }
+        }
+
+        Self {
+            data: data.into_boxed_slice(),
+        }
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[AutomataState] {
+        &self.data
+    }
+
+    #[inline]
+    pub fn clone_box(&self) -> Box<[AutomataState]> {
+        self.data.clone()
+    }
+
+    #[inline]
+    pub fn write_from_slice(&mut self, data: &[AutomataState]) {
+        self.data.as_mut().copy_from_slice(data);
+    }
+
+    /// Writes packed GPU-compatible values into the chunk.
+    pub fn write_from_packed(&mut self, data: &[u16]) {
+        debug_assert_eq!(data.len(), self.data.len());
+        for (dst, &packed) in self.data.iter_mut().zip(data.iter()) {
+            *dst = AutomataState::from(packed);
+        }
+    }
+
+    /// Returns the packed GPU representation of this chunk's voxels.
+    pub fn to_packed_vec(&self) -> Vec<u16> {
+        self.data
+            .iter()
+            .copied()
+            .map(AutomataState::to_packed)
+            .collect()
+    }
+}
+
+impl Default for ChunkCells {
+    fn default() -> Self {
+        Self::filled(AutomataState::default())
+    }
+}
+
+/// Component used as the write-target for the next CA state.
+#[derive(Component, Clone)]
+pub struct ChunkCellsNext {
+    data: Box<[AutomataState]>,
+}
+
+impl ChunkCellsNext {
+    pub fn zeros() -> Self {
+        Self {
+            data: vec![AutomataState::default(); CHUNK_VOLUME].into_boxed_slice(),
+        }
+    }
+
+    #[inline]
+    pub fn as_mut_slice(&mut self) -> &mut [AutomataState] {
+        &mut self.data
+    }
+
+    #[inline]
+    pub fn as_slice(&self) -> &[AutomataState] {
+        &self.data
+    }
+}
+
+impl Default for ChunkCellsNext {
+    fn default() -> Self {
+        Self::zeros()
+    }
+}
+
+/// Bundle wiring together the data necessary to simulate a chunk.
+#[derive(Bundle)]
+pub struct ChunkBundle {
+    pub key: ChunkKey,
+    pub cells: ChunkCells,
+    pub next: ChunkCellsNext,
+}
+
+impl ChunkBundle {
+    pub fn new(coords: IVec3) -> Self {
+        Self {
+            key: ChunkKey::new(coords),
+            cells: ChunkCells::default(),
+            next: ChunkCellsNext::default(),
+        }
+    }
+
+    pub fn from_generator<F>(coords: IVec3, generator: F) -> Self
+    where
+        F: FnMut(IVec3) -> AutomataState,
+    {
+        Self {
+            key: ChunkKey::new(coords),
+            cells: ChunkCells::from_generator(generator),
+            next: ChunkCellsNext::default(),
+        }
+    }
+}
+
+/// Resource exposing a fast lookup from chunk coordinates to ECS entity.
+#[derive(Resource, Default, Debug)]
+pub struct ChunkIndex {
+    entries: HashMap<IVec3, Entity>,
+}
+
+impl ChunkIndex {
+    pub fn entity(&self, coords: IVec3) -> Option<Entity> {
+        self.entries.get(&coords).copied()
+    }
+
+    fn rebuild(&mut self, entries: impl Iterator<Item = (IVec3, Entity)>) {
+        self.entries.clear();
+        for (coords, entity) in entries {
+            self.entries.insert(coords, entity);
+        }
+    }
+}
+
+/// Snapshot of chunk data used to evaluate the next automata state without aliasing.
+#[derive(Resource, Default, Debug)]
+pub struct ChunkSnapshots {
+    map: HashMap<IVec3, Arc<[AutomataState]>>,
+}
+
+impl ChunkSnapshots {
+    #[inline]
+    pub fn get(&self, coords: IVec3) -> Option<&[AutomataState]> {
+        self.map.get(&coords).map(|arc| arc.as_ref())
+    }
+
+    fn rebuild(&mut self, snapshots: impl Iterator<Item = (IVec3, Arc<[AutomataState]>)>) {
+        self.map.clear();
+        for (coords, snapshot) in snapshots {
+            self.map.insert(coords, snapshot);
+        }
+    }
+
+    pub fn insert(&mut self, coords: IVec3, snapshot: Arc<[AutomataState]>) {
+        self.map.insert(coords, snapshot);
+    }
+}
+
+fn accumulate_steps(clock: &mut SimulationClock, delta_seconds: f32, speed: &SimulationSpeed) {
+    clock.accumulator += delta_seconds * speed.factor;
+    clock.steps_requested = 0;
+    clock.executed_step = false;
+
+    while clock.accumulator >= FIXED_STEP_SECONDS && clock.steps_requested < MAX_STEPS_PER_FRAME {
+        clock.accumulator -= FIXED_STEP_SECONDS;
+        clock.steps_requested += 1;
+    }
+
+    if clock.steps_requested == MAX_STEPS_PER_FRAME && clock.accumulator >= FIXED_STEP_SECONDS {
+        clock.accumulator = FIXED_STEP_SECONDS;
+    }
+}
+
+/// Systems executed by the [`CellularAutomataPlugin`].
+#[derive(SystemSet, Debug, Clone, PartialEq, Eq, Hash)]
+pub enum SimulationSet {
+    Tick,
+    Snapshot,
+    Step,
+    Apply,
+}
+
+/// Plugin wiring the MVP cellular automata loop into the Bevy schedule.
+pub struct CellularAutomataPlugin;
+
+impl Plugin for CellularAutomataPlugin {
+    fn build(&self, app: &mut App) {
+        app.init_resource::<SimulationSpeed>()
+            .init_resource::<SimulationBudget>()
+            .init_resource::<SimulationClock>()
+            .init_resource::<ChunkIndex>()
+            .init_resource::<ChunkSnapshots>()
+            .insert_resource(AutomataRule::default())
+            .add_systems(First, tick_simulation.in_set(SimulationSet::Tick))
+            .add_systems(PreUpdate, snapshot_chunks.in_set(SimulationSet::Snapshot))
+            .add_systems(Update, step_chunks.in_set(SimulationSet::Step))
+            .add_systems(PostUpdate, apply_next_cells.in_set(SimulationSet::Apply));
+    }
+}
+
+fn tick_simulation(
+    time: Res<Time>,
+    mut clock: ResMut<SimulationClock>,
+    speed: Res<SimulationSpeed>,
+) {
+    accumulate_steps(&mut clock, time.delta_seconds(), &speed);
+}
+
+fn snapshot_chunks(
+    mut snapshots: ResMut<ChunkSnapshots>,
+    mut index: ResMut<ChunkIndex>,
+    clock: Res<SimulationClock>,
+    query: Query<(Entity, &ChunkKey, &ChunkCells)>,
+) {
+    if clock.steps_requested == 0 {
+        return;
+    }
+
+    let len = query.iter().len();
+    let mut snapshot_entries = Vec::with_capacity(len);
+    let mut index_entries = Vec::with_capacity(len);
+
+    for (entity, key, cells) in query.iter() {
+        snapshot_entries.push((key.coords, Arc::from(cells.clone_box())));
+        index_entries.push((key.coords, entity));
+    }
+
+    snapshots.rebuild(snapshot_entries.into_iter());
+    index.rebuild(index_entries.into_iter());
+}
+
+fn step_chunks(
+    mut clock: ResMut<SimulationClock>,
+    mut speed: ResMut<SimulationSpeed>,
+    mut budget: ResMut<SimulationBudget>,
+    mut snapshots: ResMut<ChunkSnapshots>,
+    rule: Res<AutomataRule>,
+    query: Query<(Entity, &ChunkKey)>,
+    cells_query: Query<&ChunkCells>,
+    mut next_query: Query<&mut ChunkCellsNext>,
+) {
+    let steps = clock.steps_requested.min(MAX_STEPS_PER_FRAME);
+    if steps == 0 {
+        return;
+    }
+
+    let chunk_count = query.iter().len();
+    let start = Instant::now();
+    let mut results: Vec<(Entity, IVec3, Vec<AutomataState>)> = Vec::with_capacity(chunk_count);
+
+    for step_index in 0..steps {
+        results.clear();
+
+        for (entity, key) in query.iter() {
+            if let Some(snapshot) = snapshots.get(key.coords) {
+                let mut buffer = vec![AutomataState::default(); CHUNK_VOLUME];
+                step_chunk(snapshot, key.coords, &*snapshots, &rule, &mut buffer);
+                results.push((entity, key.coords, buffer));
+            } else if let Ok(cells) = cells_query.get(entity) {
+                // No snapshot available (chunk added mid-frame); fall back to current cells.
+                let mut buffer = vec![AutomataState::default(); CHUNK_VOLUME];
+                step_chunk(
+                    cells.as_slice(),
+                    key.coords,
+                    &*snapshots,
+                    &rule,
+                    &mut buffer,
+                );
+                results.push((entity, key.coords, buffer));
+            }
+        }
+
+        let last_step = step_index == steps - 1;
+
+        for (entity, coords, buffer) in results.drain(..) {
+            let boxed = buffer.into_boxed_slice();
+
+            if last_step {
+                if let Ok(mut next) = next_query.get_mut(entity) {
+                    next.as_mut_slice().copy_from_slice(&boxed);
+                }
+            }
+
+            snapshots.insert(coords, Arc::from(boxed));
+        }
+    }
+
+    let elapsed_ms = start.elapsed().as_secs_f32() * 1000.0;
+    budget.record_step(elapsed_ms);
+    speed.apply_budget_feedback(&budget);
+    clock.steps_requested = 0;
+    clock.executed_step = true;
+}
+
+fn apply_next_cells(
+    mut clock: ResMut<SimulationClock>,
+    mut query: Query<(&mut ChunkCells, &ChunkCellsNext)>,
+) {
+    if !clock.executed_step {
+        return;
+    }
+
+    for (mut cells, next) in query.iter_mut() {
+        cells.write_from_slice(next.as_slice());
+    }
+
+    clock.executed_step = false;
+}
+
+fn step_chunk(
+    current_chunk: &[AutomataState],
+    coords: IVec3,
+    snapshots: &ChunkSnapshots,
+    rule: &AutomataRule,
+    output: &mut [AutomataState],
+) {
+    for x in 0..CHUNK_EDGE {
+        for y in 0..CHUNK_EDGE {
+            for z in 0..CHUNK_EDGE {
+                let local = IVec3::new(x, y, z);
+                let idx = linear_index(local);
+                let neighbors = count_active_neighbors(snapshots, coords, local);
+                let current = current_chunk[idx];
+                output[idx] = rule.next_state(current, neighbors);
+            }
+        }
+    }
+}
+
+fn count_active_neighbors(snapshots: &ChunkSnapshots, chunk_coords: IVec3, local: IVec3) -> u8 {
+    let mut count = 0u8;
+
+    for dx in -1..=1 {
+        for dy in -1..=1 {
+            for dz in -1..=1 {
+                if dx == 0 && dy == 0 && dz == 0 {
+                    continue;
+                }
+
+                let offset = IVec3::new(dx, dy, dz);
+                if let Some(value) = sample_cell(snapshots, chunk_coords, local + offset) {
+                    if value.is_alive() {
+                        count = count.saturating_add(1);
+                    }
+                }
+            }
+        }
+    }
+
+    count
+}
+
+fn sample_cell(
+    snapshots: &ChunkSnapshots,
+    mut chunk_coords: IVec3,
+    mut local: IVec3,
+) -> Option<AutomataState> {
+    let edge = CHUNK_EDGE;
+
+    if local.x < 0 {
+        chunk_coords.x -= 1;
+        local.x += edge;
+    } else if local.x >= edge {
+        chunk_coords.x += 1;
+        local.x -= edge;
+    }
+
+    if local.y < 0 {
+        chunk_coords.y -= 1;
+        local.y += edge;
+    } else if local.y >= edge {
+        chunk_coords.y += 1;
+        local.y -= edge;
+    }
+
+    if local.z < 0 {
+        chunk_coords.z -= 1;
+        local.z += edge;
+    } else if local.z >= edge {
+        chunk_coords.z += 1;
+        local.z -= edge;
+    }
+
+    if let Some(chunk) = snapshots.get(chunk_coords) {
+        let index = linear_index(local);
+        Some(chunk[index])
+    } else {
+        None
+    }
+}
+
+#[inline]
+fn linear_index(local: IVec3) -> usize {
+    let edge = CHUNK_EDGE as usize;
+    (local.x as usize * edge * edge) + (local.y as usize * edge) + local.z as usize
+}
+
+#[inline]
+fn morton_encode(coords: IVec3) -> u64 {
+    let x = (coords.x + MORTON_BIAS) as u64;
+    let y = (coords.y + MORTON_BIAS) as u64;
+    let z = (coords.z + MORTON_BIAS) as u64;
+
+    part1by2(x) | (part1by2(y) << 1) | (part1by2(z) << 2)
+}
+
+#[inline]
+fn part1by2(mut n: u64) -> u64 {
+    n &= 0x1f_ffff;
+    n = (n | (n << 32)) & 0x1f00_0000_00ff_ff;
+    n = (n | (n << 16)) & 0x1f00_00ff_0000_ff;
+    n = (n | (n << 8)) & 0x100f_00f0_0f00_f00f;
+    n = (n | (n << 4)) & 0x10c3_0c30_c30c_30c3;
+    n = (n | (n << 2)) & 0x1249_2492_4924_9249;
+    n
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::Flags;
+    use bevy::ecs::{
+        system::{Query, Res, ResMut, SystemState},
+        world::World,
+    };
+    use std::collections::HashSet;
+
+    #[test]
+    fn morton_keys_are_unique_for_local_region() {
+        let mut seen = HashSet::new();
+        for x in -2..=2 {
+            for y in -2..=2 {
+                for z in -2..=2 {
+                    let key = morton_encode(IVec3::new(x, y, z));
+                    assert!(seen.insert(key));
+                }
+            }
+        }
+    }
+
+    #[test]
+    fn neighbor_lookup_crosses_chunk_boundary() {
+        let mut snapshots = ChunkSnapshots::default();
+        let mut map = HashMap::default();
+
+        let mut center = vec![AutomataState::default(); CHUNK_VOLUME];
+        center[linear_index(IVec3::new(CHUNK_EDGE - 1, CHUNK_EDGE - 1, CHUNK_EDGE - 1))] =
+            AutomataState::from_components(1, Flags::AUTOMATA_FLAG);
+        map.insert(IVec3::ZERO, Arc::from(center.into_boxed_slice()));
+
+        let mut neighbor = vec![AutomataState::default(); CHUNK_VOLUME];
+        neighbor[linear_index(IVec3::new(0, 0, 0))] =
+            AutomataState::from_components(1, Flags::AUTOMATA_FLAG);
+        map.insert(IVec3::new(1, 1, 1), Arc::from(neighbor.into_boxed_slice()));
+
+        snapshots.map = map;
+
+        let count = count_active_neighbors(
+            &snapshots,
+            IVec3::ZERO,
+            IVec3::new(CHUNK_EDGE - 1, CHUNK_EDGE - 1, CHUNK_EDGE - 1),
+        );
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn multiple_steps_drain_accumulator() {
+        let mut world = World::default();
+        world.insert_resource(SimulationClock::default());
+        world.insert_resource(SimulationSpeed::default());
+        world.insert_resource(SimulationBudget::default());
+        world.insert_resource(ChunkSnapshots::default());
+        world.insert_resource(ChunkIndex::default());
+        world.insert_resource(AutomataRule::default());
+
+        world.spawn(ChunkBundle::new(IVec3::ZERO));
+
+        let speed_clone = { world.resource::<SimulationSpeed>().clone() };
+        {
+            let mut clock = world.resource_mut::<SimulationClock>();
+            accumulate_steps(&mut clock, FIXED_STEP_SECONDS * 3.5, &speed_clone);
+        }
+
+        {
+            let mut system_state: SystemState<(
+                ResMut<ChunkSnapshots>,
+                ResMut<ChunkIndex>,
+                Res<SimulationClock>,
+                Query<(Entity, &ChunkKey, &ChunkCells)>,
+            )> = SystemState::new(&mut world);
+            let (snapshots, index, clock, query) = system_state.get_mut(&mut world);
+            snapshot_chunks(snapshots, index, clock, query);
+            system_state.apply(&mut world);
+        }
+
+        {
+            let mut system_state: SystemState<(
+                ResMut<SimulationClock>,
+                ResMut<SimulationSpeed>,
+                ResMut<SimulationBudget>,
+                ResMut<ChunkSnapshots>,
+                Res<AutomataRule>,
+                Query<(Entity, &ChunkKey)>,
+                Query<&ChunkCells>,
+                Query<&mut ChunkCellsNext>,
+            )> = SystemState::new(&mut world);
+            let (clock, speed, budget, snapshots, rule, query, cells_query, next_query) =
+                system_state.get_mut(&mut world);
+            step_chunks(
+                clock,
+                speed,
+                budget,
+                snapshots,
+                rule,
+                query,
+                cells_query,
+                next_query,
+            );
+            system_state.apply(&mut world);
+        }
+
+        let clock = world.resource::<SimulationClock>();
+        assert!(clock.accumulator < FIXED_STEP_SECONDS);
+        assert_eq!(clock.steps_requested, 0);
+        assert!(clock.executed_step);
+    }
+}

--- a/src/voxel_pipeline/compute/animation.rs
+++ b/src/voxel_pipeline/compute/animation.rs
@@ -21,8 +21,9 @@ impl FromWorld for Pipeline {
         let compute_bind_group_layout = world.resource::<ComputeData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/animation.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/animation.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("animation pipeline")),

--- a/src/voxel_pipeline/compute/automata.rs
+++ b/src/voxel_pipeline/compute/automata.rs
@@ -24,8 +24,9 @@ impl FromWorld for Pipeline {
         let compute_bind_group_layout = world.resource::<ComputeData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/automata.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/automata.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("automata pipeline")),

--- a/src/voxel_pipeline/compute/clear.rs
+++ b/src/voxel_pipeline/compute/clear.rs
@@ -22,8 +22,9 @@ impl FromWorld for Pipeline {
         let voxel_bind_group_layout = world.resource::<VoxelData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/clear.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/clear.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("clear pipeline")),

--- a/src/voxel_pipeline/compute/physics.rs
+++ b/src/voxel_pipeline/compute/physics.rs
@@ -21,8 +21,9 @@ impl FromWorld for Pipeline {
         let compute_bind_group_layout = world.resource::<ComputeData>().bind_group_layout.clone();
 
         let asset_server = world.resource::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/physics.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/physics.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("physics pipeline")),

--- a/src/voxel_pipeline/compute/rebuild.rs
+++ b/src/voxel_pipeline/compute/rebuild.rs
@@ -23,8 +23,9 @@ impl FromWorld for Pipeline {
         let voxel_bind_group_layout = world.resource::<VoxelData>().bind_group_layout.clone();
 
         let asset_server = world.resource_mut::<AssetServer>();
-        let shader = asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/rebuild.wgsl");
-        
+        let shader =
+            asset_server.load("embedded://bevy_voxel_engine/voxel_pipeline/compute/rebuild.wgsl");
+
         let pipeline_cache = world.resource_mut::<PipelineCache>();
         let update_pipeline = pipeline_cache.queue_compute_pipeline(ComputePipelineDescriptor {
             label: Some(Cow::from("rebuild pipeline")),

--- a/src/voxel_pipeline/voxelization.rs
+++ b/src/voxel_pipeline/voxelization.rs
@@ -286,7 +286,7 @@ impl SpecializedMeshPipeline for VoxelizationPipeline {
         descriptor.vertex.shader = VOXELIZATION_SHADER_HANDLE;
         descriptor.fragment.as_mut().unwrap().shader = VOXELIZATION_SHADER_HANDLE;
 
-        // 
+        //
         descriptor
             .vertex
             .shader_defs


### PR DESCRIPTION
## Summary
- implement a packed AutomataState and fixed-step cellular automata runtime with chunk snapshots, Morton keys, and adaptive simulation budgets
- wire the new CellularAutomataPlugin into the engine and document GPU interop plus scaling research for big_space, ilattice, and oktree
- refresh ROADMAP_MVP.md with concrete glue code and integration steps for scaling from room-sized simulations to a destructible planet

## Testing
- cargo test --lib

------
https://chatgpt.com/codex/tasks/task_e_68d8ba17b8fc8328af2b3002fe5a4302